### PR TITLE
SelectLocationVC 건물 선택 화면 구현

### DIFF
--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		877F534129F6400900A0F931 /* BuildingApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534029F6400900A0F931 /* BuildingApiService.swift */; };
 		877F534329F642EC00A0F931 /* BuildingRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534229F642EC00A0F931 /* BuildingRepositoryInterface.swift */; };
 		877F534529F643B600A0F931 /* BuildingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534429F643B600A0F931 /* BuildingRepository.swift */; };
-		877F534929F666AF00A0F931 /* BuildingListCellCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534829F666AF00A0F931 /* BuildingListCellCollectionViewCell.swift */; };
+		877F534929F666AF00A0F931 /* BuildingListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534829F666AF00A0F931 /* BuildingListCollectionViewCell.swift */; };
 		8793524F29B9D8F200D6A079 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793524E29B9D8F200D6A079 /* Utils.swift */; };
 		87ABC85B29D175A700881FFB /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85A29D175A700881FFB /* Network.swift */; };
 		87ABC85D29D176C700881FFB /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85C29D176C700881FFB /* NetworkResult.swift */; };
@@ -63,7 +63,7 @@
 		877F534029F6400900A0F931 /* BuildingApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingApiService.swift; sourceTree = "<group>"; };
 		877F534229F642EC00A0F931 /* BuildingRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingRepositoryInterface.swift; sourceTree = "<group>"; };
 		877F534429F643B600A0F931 /* BuildingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingRepository.swift; sourceTree = "<group>"; };
-		877F534829F666AF00A0F931 /* BuildingListCellCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingListCellCollectionViewCell.swift; sourceTree = "<group>"; };
+		877F534829F666AF00A0F931 /* BuildingListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingListCollectionViewCell.swift; sourceTree = "<group>"; };
 		8793524E29B9D8F200D6A079 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		87ABC85929D173BC00881FFB /* env.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = env.xcconfig; sourceTree = "<group>"; };
 		87ABC85A29D175A700881FFB /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
@@ -254,7 +254,7 @@
 				87C8FB0429F22E1B000C37CE /* RoadAddressLabel.swift */,
 				87C8FB1629F28F8A000C37CE /* SelectLocationLargeButton.swift */,
 				877F533A29F62E2300A0F931 /* BackButton.swift */,
-				877F534829F666AF00A0F931 /* BuildingListCellCollectionViewCell.swift */,
+				877F534829F666AF00A0F931 /* BuildingListCollectionViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -444,7 +444,7 @@
 				87ABC87129D30EE000881FFB /* MeasuredData.swift in Sources */,
 				87C8FAF929F171D1000C37CE /* SelectLocationVC.swift in Sources */,
 				87ABC85F29D176F700881FFB /* NetworkStatus.swift in Sources */,
-				877F534929F666AF00A0F931 /* BuildingListCellCollectionViewCell.swift in Sources */,
+				877F534929F666AF00A0F931 /* BuildingListCollectionViewCell.swift in Sources */,
 				E73DD13124636FEF00D77039 /* AppDelegate.swift in Sources */,
 				87C8FB1329F24EDF000C37CE /* FetchError.swift in Sources */,
 			);

--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		8711C71429D131A200F6D5CC /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 8711C71329D131A200F6D5CC /* Alamofire */; };
 		872C7A9E29F1332B002D91D2 /* LocationUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872C7A9D29F1332B002D91D2 /* LocationUsecase.swift */; };
 		8749E16A29EEE2940093F7A7 /* PointCloudCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8749E16929EEE2940093F7A7 /* PointCloudCountView.swift */; };
+		877F533B29F62E2300A0F931 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533A29F62E2300A0F931 /* BackButton.swift */; };
 		8793524F29B9D8F200D6A079 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793524E29B9D8F200D6A079 /* Utils.swift */; };
 		87ABC85B29D175A700881FFB /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85A29D175A700881FFB /* Network.swift */; };
 		87ABC85D29D176C700881FFB /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85C29D176C700881FFB /* NetworkResult.swift */; };
@@ -50,6 +51,7 @@
 /* Begin PBXFileReference section */
 		872C7A9D29F1332B002D91D2 /* LocationUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationUsecase.swift; sourceTree = "<group>"; };
 		8749E16929EEE2940093F7A7 /* PointCloudCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointCloudCountView.swift; sourceTree = "<group>"; };
+		877F533A29F62E2300A0F931 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		8793524E29B9D8F200D6A079 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		87ABC85929D173BC00881FFB /* env.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = env.xcconfig; sourceTree = "<group>"; };
 		87ABC85A29D175A700881FFB /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
@@ -237,6 +239,7 @@
 				87C8FAFF29F1911B000C37CE /* CancelButton.swift */,
 				87C8FB0429F22E1B000C37CE /* RoadAddressLabel.swift */,
 				87C8FB1629F28F8A000C37CE /* SelectLocationLargeButton.swift */,
+				877F533A29F62E2300A0F931 /* BackButton.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -404,6 +407,7 @@
 				E7B7223B24807ACA002E43E8 /* MetalBuffer.swift in Sources */,
 				872C7A9E29F1332B002D91D2 /* LocationUsecase.swift in Sources */,
 				87C8FB1529F263C8000C37CE /* NetworkInterceptor.swift in Sources */,
+				877F533B29F62E2300A0F931 /* BackButton.swift in Sources */,
 				87C8FAFE29F18DB3000C37CE /* SelectLocationTitleLabel.swift in Sources */,
 				87ABC86229D178BD00881FFB /* MainApiService.swift in Sources */,
 				8749E16A29EEE2940093F7A7 /* PointCloudCountView.swift in Sources */,

--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		877F533F29F63E1F00A0F931 /* BuildingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533E29F63E1F00A0F931 /* BuildingInfo.swift */; };
 		877F534129F6400900A0F931 /* BuildingApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534029F6400900A0F931 /* BuildingApiService.swift */; };
 		877F534329F642EC00A0F931 /* BuildingRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534229F642EC00A0F931 /* BuildingRepositoryInterface.swift */; };
+		877F534529F643B600A0F931 /* BuildingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534429F643B600A0F931 /* BuildingRepository.swift */; };
 		8793524F29B9D8F200D6A079 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793524E29B9D8F200D6A079 /* Utils.swift */; };
 		87ABC85B29D175A700881FFB /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85A29D175A700881FFB /* Network.swift */; };
 		87ABC85D29D176C700881FFB /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85C29D176C700881FFB /* NetworkResult.swift */; };
@@ -60,6 +61,7 @@
 		877F533E29F63E1F00A0F931 /* BuildingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingInfo.swift; sourceTree = "<group>"; };
 		877F534029F6400900A0F931 /* BuildingApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingApiService.swift; sourceTree = "<group>"; };
 		877F534229F642EC00A0F931 /* BuildingRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingRepositoryInterface.swift; sourceTree = "<group>"; };
+		877F534429F643B600A0F931 /* BuildingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingRepository.swift; sourceTree = "<group>"; };
 		8793524E29B9D8F200D6A079 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		87ABC85929D173BC00881FFB /* env.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = env.xcconfig; sourceTree = "<group>"; };
 		87ABC85A29D175A700881FFB /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
@@ -266,6 +268,7 @@
 			isa = PBXGroup;
 			children = (
 				87C8FB0929F23717000C37CE /* AddressRepository.swift */,
+				877F534429F643B600A0F931 /* BuildingRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -409,6 +412,7 @@
 				E7B7223D24809D1E002E43E8 /* Helpers.swift in Sources */,
 				87AE167829F124EF00B101A6 /* LocationData.swift in Sources */,
 				87ABC85B29D175A700881FFB /* Network.swift in Sources */,
+				877F534529F643B600A0F931 /* BuildingRepository.swift in Sources */,
 				87C8FB0D29F2382C000C37CE /* AddressRepositoryInterface.swift in Sources */,
 				87ABC86E29D3041100881FFB /* StatusIndicatorLabel.swift in Sources */,
 				87FDBC1E29EEA53C00D90D02 /* LiDARData.swift in Sources */,

--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		877F534329F642EC00A0F931 /* BuildingRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534229F642EC00A0F931 /* BuildingRepositoryInterface.swift */; };
 		877F534529F643B600A0F931 /* BuildingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534429F643B600A0F931 /* BuildingRepository.swift */; };
 		877F534929F666AF00A0F931 /* BuildingListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534829F666AF00A0F931 /* BuildingListCollectionViewCell.swift */; };
+		877F534B29F69D1600A0F931 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534A29F69D1600A0F931 /* UIView+Extension.swift */; };
 		8793524F29B9D8F200D6A079 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793524E29B9D8F200D6A079 /* Utils.swift */; };
 		87ABC85B29D175A700881FFB /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85A29D175A700881FFB /* Network.swift */; };
 		87ABC85D29D176C700881FFB /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85C29D176C700881FFB /* NetworkResult.swift */; };
@@ -64,6 +65,7 @@
 		877F534229F642EC00A0F931 /* BuildingRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingRepositoryInterface.swift; sourceTree = "<group>"; };
 		877F534429F643B600A0F931 /* BuildingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingRepository.swift; sourceTree = "<group>"; };
 		877F534829F666AF00A0F931 /* BuildingListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingListCollectionViewCell.swift; sourceTree = "<group>"; };
+		877F534A29F69D1600A0F931 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		8793524E29B9D8F200D6A079 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		87ABC85929D173BC00881FFB /* env.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = env.xcconfig; sourceTree = "<group>"; };
 		87ABC85A29D175A700881FFB /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				87ABC86629D1946400881FFB /* UIViewController+Extension.swift */,
+				877F534A29F69D1600A0F931 /* UIView+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -442,6 +445,7 @@
 				877F533D29F6328D00A0F931 /* BuildingNearByGpsDTO.swift in Sources */,
 				E73DD13824636FEF00D77039 /* MainVC.swift in Sources */,
 				87ABC87129D30EE000881FFB /* MeasuredData.swift in Sources */,
+				877F534B29F69D1600A0F931 /* UIView+Extension.swift in Sources */,
 				87C8FAF929F171D1000C37CE /* SelectLocationVC.swift in Sources */,
 				87ABC85F29D176F700881FFB /* NetworkStatus.swift in Sources */,
 				877F534929F666AF00A0F931 /* BuildingListCollectionViewCell.swift in Sources */,

--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		872C7A9E29F1332B002D91D2 /* LocationUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872C7A9D29F1332B002D91D2 /* LocationUsecase.swift */; };
 		8749E16A29EEE2940093F7A7 /* PointCloudCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8749E16929EEE2940093F7A7 /* PointCloudCountView.swift */; };
 		877F533B29F62E2300A0F931 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533A29F62E2300A0F931 /* BackButton.swift */; };
+		877F533D29F6328D00A0F931 /* BuildingNearByGpsDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533C29F6328D00A0F931 /* BuildingNearByGpsDTO.swift */; };
 		8793524F29B9D8F200D6A079 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793524E29B9D8F200D6A079 /* Utils.swift */; };
 		87ABC85B29D175A700881FFB /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85A29D175A700881FFB /* Network.swift */; };
 		87ABC85D29D176C700881FFB /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85C29D176C700881FFB /* NetworkResult.swift */; };
@@ -52,6 +53,7 @@
 		872C7A9D29F1332B002D91D2 /* LocationUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationUsecase.swift; sourceTree = "<group>"; };
 		8749E16929EEE2940093F7A7 /* PointCloudCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointCloudCountView.swift; sourceTree = "<group>"; };
 		877F533A29F62E2300A0F931 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
+		877F533C29F6328D00A0F931 /* BuildingNearByGpsDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingNearByGpsDTO.swift; sourceTree = "<group>"; };
 		8793524E29B9D8F200D6A079 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		87ABC85929D173BC00881FFB /* env.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = env.xcconfig; sourceTree = "<group>"; };
 		87ABC85A29D175A700881FFB /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
@@ -217,6 +219,7 @@
 			children = (
 				87ABC87029D30EE000881FFB /* MeasuredData.swift */,
 				87C8FB1029F23ADE000C37CE /* AddressFromGpsDTO.swift */,
+				877F533C29F6328D00A0F931 /* BuildingNearByGpsDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -417,6 +420,7 @@
 				87C8FB0A29F23717000C37CE /* AddressRepository.swift in Sources */,
 				87C8FAFB29F1867E000C37CE /* SelectLocationVM.swift in Sources */,
 				E73DD13624636FEF00D77039 /* Renderer.swift in Sources */,
+				877F533D29F6328D00A0F931 /* BuildingNearByGpsDTO.swift in Sources */,
 				E73DD13824636FEF00D77039 /* MainVC.swift in Sources */,
 				87ABC87129D30EE000881FFB /* MeasuredData.swift in Sources */,
 				87C8FAF929F171D1000C37CE /* SelectLocationVC.swift in Sources */,

--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		877F533D29F6328D00A0F931 /* BuildingNearByGpsDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533C29F6328D00A0F931 /* BuildingNearByGpsDTO.swift */; };
 		877F533F29F63E1F00A0F931 /* BuildingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533E29F63E1F00A0F931 /* BuildingInfo.swift */; };
 		877F534129F6400900A0F931 /* BuildingApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534029F6400900A0F931 /* BuildingApiService.swift */; };
+		877F534329F642EC00A0F931 /* BuildingRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534229F642EC00A0F931 /* BuildingRepositoryInterface.swift */; };
 		8793524F29B9D8F200D6A079 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793524E29B9D8F200D6A079 /* Utils.swift */; };
 		87ABC85B29D175A700881FFB /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85A29D175A700881FFB /* Network.swift */; };
 		87ABC85D29D176C700881FFB /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85C29D176C700881FFB /* NetworkResult.swift */; };
@@ -58,6 +59,7 @@
 		877F533C29F6328D00A0F931 /* BuildingNearByGpsDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingNearByGpsDTO.swift; sourceTree = "<group>"; };
 		877F533E29F63E1F00A0F931 /* BuildingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingInfo.swift; sourceTree = "<group>"; };
 		877F534029F6400900A0F931 /* BuildingApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingApiService.swift; sourceTree = "<group>"; };
+		877F534229F642EC00A0F931 /* BuildingRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingRepositoryInterface.swift; sourceTree = "<group>"; };
 		8793524E29B9D8F200D6A079 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		87ABC85929D173BC00881FFB /* env.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = env.xcconfig; sourceTree = "<group>"; };
 		87ABC85A29D175A700881FFB /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
@@ -272,6 +274,7 @@
 			isa = PBXGroup;
 			children = (
 				87C8FB0C29F2382C000C37CE /* AddressRepositoryInterface.swift */,
+				877F534229F642EC00A0F931 /* BuildingRepositoryInterface.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -427,6 +430,7 @@
 				87ABC86C29D290E900881FFB /* RecordingButton.swift in Sources */,
 				87C8FB0A29F23717000C37CE /* AddressRepository.swift in Sources */,
 				87C8FAFB29F1867E000C37CE /* SelectLocationVM.swift in Sources */,
+				877F534329F642EC00A0F931 /* BuildingRepositoryInterface.swift in Sources */,
 				E73DD13624636FEF00D77039 /* Renderer.swift in Sources */,
 				877F533D29F6328D00A0F931 /* BuildingNearByGpsDTO.swift in Sources */,
 				E73DD13824636FEF00D77039 /* MainVC.swift in Sources */,

--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		877F533B29F62E2300A0F931 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533A29F62E2300A0F931 /* BackButton.swift */; };
 		877F533D29F6328D00A0F931 /* BuildingNearByGpsDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533C29F6328D00A0F931 /* BuildingNearByGpsDTO.swift */; };
 		877F533F29F63E1F00A0F931 /* BuildingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533E29F63E1F00A0F931 /* BuildingInfo.swift */; };
+		877F534129F6400900A0F931 /* BuildingApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534029F6400900A0F931 /* BuildingApiService.swift */; };
 		8793524F29B9D8F200D6A079 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793524E29B9D8F200D6A079 /* Utils.swift */; };
 		87ABC85B29D175A700881FFB /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85A29D175A700881FFB /* Network.swift */; };
 		87ABC85D29D176C700881FFB /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85C29D176C700881FFB /* NetworkResult.swift */; };
@@ -56,6 +57,7 @@
 		877F533A29F62E2300A0F931 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		877F533C29F6328D00A0F931 /* BuildingNearByGpsDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingNearByGpsDTO.swift; sourceTree = "<group>"; };
 		877F533E29F63E1F00A0F931 /* BuildingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingInfo.swift; sourceTree = "<group>"; };
+		877F534029F6400900A0F931 /* BuildingApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingApiService.swift; sourceTree = "<group>"; };
 		8793524E29B9D8F200D6A079 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		87ABC85929D173BC00881FFB /* env.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = env.xcconfig; sourceTree = "<group>"; };
 		87ABC85A29D175A700881FFB /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 			children = (
 				87ABC86129D178BD00881FFB /* MainApiService.swift */,
 				87C8FB0E29F238DA000C37CE /* AddressApiService.swift */,
+				877F534029F6400900A0F931 /* BuildingApiService.swift */,
 			);
 			path = ApiService;
 			sourceTree = "<group>";
@@ -410,6 +413,7 @@
 				87C8FB0529F22E1B000C37CE /* RoadAddressLabel.swift in Sources */,
 				87C8FB0029F1911B000C37CE /* CancelButton.swift in Sources */,
 				87C8FB1729F28F8A000C37CE /* SelectLocationLargeButton.swift in Sources */,
+				877F534129F6400900A0F931 /* BuildingApiService.swift in Sources */,
 				87ABC86729D1946400881FFB /* UIViewController+Extension.swift in Sources */,
 				E7B7223B24807ACA002E43E8 /* MetalBuffer.swift in Sources */,
 				872C7A9E29F1332B002D91D2 /* LocationUsecase.swift in Sources */,

--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		877F534129F6400900A0F931 /* BuildingApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534029F6400900A0F931 /* BuildingApiService.swift */; };
 		877F534329F642EC00A0F931 /* BuildingRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534229F642EC00A0F931 /* BuildingRepositoryInterface.swift */; };
 		877F534529F643B600A0F931 /* BuildingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534429F643B600A0F931 /* BuildingRepository.swift */; };
+		877F534929F666AF00A0F931 /* BuildingListCellCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534829F666AF00A0F931 /* BuildingListCellCollectionViewCell.swift */; };
 		8793524F29B9D8F200D6A079 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793524E29B9D8F200D6A079 /* Utils.swift */; };
 		87ABC85B29D175A700881FFB /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85A29D175A700881FFB /* Network.swift */; };
 		87ABC85D29D176C700881FFB /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85C29D176C700881FFB /* NetworkResult.swift */; };
@@ -62,6 +63,7 @@
 		877F534029F6400900A0F931 /* BuildingApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingApiService.swift; sourceTree = "<group>"; };
 		877F534229F642EC00A0F931 /* BuildingRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingRepositoryInterface.swift; sourceTree = "<group>"; };
 		877F534429F643B600A0F931 /* BuildingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingRepository.swift; sourceTree = "<group>"; };
+		877F534829F666AF00A0F931 /* BuildingListCellCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingListCellCollectionViewCell.swift; sourceTree = "<group>"; };
 		8793524E29B9D8F200D6A079 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		87ABC85929D173BC00881FFB /* env.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = env.xcconfig; sourceTree = "<group>"; };
 		87ABC85A29D175A700881FFB /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
@@ -252,6 +254,7 @@
 				87C8FB0429F22E1B000C37CE /* RoadAddressLabel.swift */,
 				87C8FB1629F28F8A000C37CE /* SelectLocationLargeButton.swift */,
 				877F533A29F62E2300A0F931 /* BackButton.swift */,
+				877F534829F666AF00A0F931 /* BuildingListCellCollectionViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -441,6 +444,7 @@
 				87ABC87129D30EE000881FFB /* MeasuredData.swift in Sources */,
 				87C8FAF929F171D1000C37CE /* SelectLocationVC.swift in Sources */,
 				87ABC85F29D176F700881FFB /* NetworkStatus.swift in Sources */,
+				877F534929F666AF00A0F931 /* BuildingListCellCollectionViewCell.swift in Sources */,
 				E73DD13124636FEF00D77039 /* AppDelegate.swift in Sources */,
 				87C8FB1329F24EDF000C37CE /* FetchError.swift in Sources */,
 			);

--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		8749E16A29EEE2940093F7A7 /* PointCloudCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8749E16929EEE2940093F7A7 /* PointCloudCountView.swift */; };
 		877F533B29F62E2300A0F931 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533A29F62E2300A0F931 /* BackButton.swift */; };
 		877F533D29F6328D00A0F931 /* BuildingNearByGpsDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533C29F6328D00A0F931 /* BuildingNearByGpsDTO.swift */; };
+		877F533F29F63E1F00A0F931 /* BuildingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533E29F63E1F00A0F931 /* BuildingInfo.swift */; };
 		8793524F29B9D8F200D6A079 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793524E29B9D8F200D6A079 /* Utils.swift */; };
 		87ABC85B29D175A700881FFB /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85A29D175A700881FFB /* Network.swift */; };
 		87ABC85D29D176C700881FFB /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85C29D176C700881FFB /* NetworkResult.swift */; };
@@ -54,6 +55,7 @@
 		8749E16929EEE2940093F7A7 /* PointCloudCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointCloudCountView.swift; sourceTree = "<group>"; };
 		877F533A29F62E2300A0F931 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		877F533C29F6328D00A0F931 /* BuildingNearByGpsDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingNearByGpsDTO.swift; sourceTree = "<group>"; };
+		877F533E29F63E1F00A0F931 /* BuildingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingInfo.swift; sourceTree = "<group>"; };
 		8793524E29B9D8F200D6A079 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		87ABC85929D173BC00881FFB /* env.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = env.xcconfig; sourceTree = "<group>"; };
 		87ABC85A29D175A700881FFB /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
@@ -277,6 +279,7 @@
 				87FDBC1D29EEA53C00D90D02 /* LiDARData.swift */,
 				87AE167729F124EF00B101A6 /* LocationData.swift */,
 				87C8FB1229F24EDF000C37CE /* FetchError.swift */,
+				877F533E29F63E1F00A0F931 /* BuildingInfo.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -394,6 +397,7 @@
 				87ABC86429D1924900881FFB /* NetworkURL.swift in Sources */,
 				87C8FB0329F1933B000C37CE /* SelectLocationDelegate.swift in Sources */,
 				87FDBC1B29EE270A00D90D02 /* MainVM.swift in Sources */,
+				877F533F29F63E1F00A0F931 /* BuildingInfo.swift in Sources */,
 				E73DD13324636FEF00D77039 /* Shaders.metal in Sources */,
 				87C8FB1129F23ADE000C37CE /* AddressFromGpsDTO.swift in Sources */,
 				E7B7223D24809D1E002E43E8 /* Helpers.swift in Sources */,

--- a/SceneDepthPointCloud/Assets.xcassets/buildingCellBackgroundColor.colorset/Contents.json
+++ b/SceneDepthPointCloud/Assets.xcassets/buildingCellBackgroundColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x20",
+          "green" : "0x20",
+          "red" : "0x20"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SceneDepthPointCloud/Assets.xcassets/deActivateMainColor.colorset/Contents.json
+++ b/SceneDepthPointCloud/Assets.xcassets/deActivateMainColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.500",
+          "blue" : "0x47",
+          "green" : "0x5C",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SceneDepthPointCloud/Data/ApiService/AddressApiService.swift
+++ b/SceneDepthPointCloud/Data/ApiService/AddressApiService.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Address 수신받기 위한 Network Service 담당
 struct AddressApiService {
-    /// KakaoAPI 를 통해 AddressFromGpsDTO 를 반환하는 함수
+    /// KakaoAPI를 통해 AddressFromGpsDTO를 반환하는 함수
     func getCoordToAddress(x: Double, y: Double, completion: @escaping (Result<AddressFromGpsDTO, FetchError>) -> Void) {
         let parameters = ["x": x, "y": y]
         
@@ -18,19 +18,19 @@ struct AddressApiService {
             switch result.status {
             case .SUCCESS:
                 guard let data = result.data else {
-                    completion(.failure(FetchError.empty))
+                    completion(.failure(.empty))
                     return
                 }
                 
                 guard let dto = try? JSONDecoder().decode(AddressFromGpsDTO.self, from: data) else {
-                    completion(.failure(FetchError.decode))
+                    completion(.failure(.decode))
                     return
                 }
                 
                 completion(.success(dto))
                 
             case .ERROR(let statusCode):
-                completion(.failure(FetchError.server(statusCode)))
+                completion(.failure(.server(statusCode)))
             }
         }
     }

--- a/SceneDepthPointCloud/Data/ApiService/BuildingApiService.swift
+++ b/SceneDepthPointCloud/Data/ApiService/BuildingApiService.swift
@@ -18,7 +18,7 @@ struct BuildingApiService {
         parameters["sort"] = "distance" // 거리값 기준 정렬로 고정
         parameters["category_group_code"] = " " // 모든 카테고리 값으로 고정
         
-        Network.request(url: NetworkURL.Kakao.searchByCategory, method: .get) { result in
+        Network.request(url: NetworkURL.Kakao.searchByCategory, method: .get, parameters: parameters) { result in
             switch result.status {
             case .SUCCESS:
                 guard let data = result.data else {

--- a/SceneDepthPointCloud/Data/ApiService/BuildingApiService.swift
+++ b/SceneDepthPointCloud/Data/ApiService/BuildingApiService.swift
@@ -1,0 +1,41 @@
+//
+//  BuildingApiService.swift
+//  SceneDepthPointCloud
+//
+//  Created by Kang Minsang on 2023/04/24.
+//  Copyright © 2023 Apple. All rights reserved.
+//
+
+import Foundation
+
+/// Building 정보를 수신받기 위한 Network Service 담당
+struct BuildingApiService {
+    /// KakaoAPI를 통해 BuildingNearByGpsDTO를 반환하는 함수
+    func getSearchByCategory(x: Double, y: Double, page: Int, completion: @escaping (Result<BuildingNearByGpsDTO, FetchError>) -> Void) {
+        var parameters: [String: Any] = ["x": x, "y": y, "page": page]
+        // KakaoAPI에 필요한 추가 parameter들 (고정값들)
+        parameters["radius"] = 100 // 100m로 고정
+        parameters["sort"] = "distance" // 거리값 기준 정렬로 고정
+        parameters["category_group_code"] = " " // 모든 카테고리 값으로 고정
+        
+        Network.request(url: NetworkURL.Kakao.searchByCategory, method: .get) { result in
+            switch result.status {
+            case .SUCCESS:
+                guard let data = result.data else {
+                    completion(.failure(.empty))
+                    return
+                }
+                
+                guard let dto = try? JSONDecoder().decode(BuildingNearByGpsDTO.self, from: data) else {
+                    completion(.failure(.decode))
+                    return
+                }
+                
+                completion(.success(dto))
+                
+            case .ERROR(let statusCode):
+                completion(.failure(.server(statusCode)))
+            }
+        }
+    }
+}

--- a/SceneDepthPointCloud/Data/DTO/BuildingNearByGpsDTO.swift
+++ b/SceneDepthPointCloud/Data/DTO/BuildingNearByGpsDTO.swift
@@ -54,4 +54,19 @@ struct BuildingNearByGpsDocumentDTO: Decodable {
         case longitude = "x"
         case latitude = "y"
     }
+    
+    func toDomain() -> BuildingInfo {
+        return .init(roadAddress: self.addressName,
+                     placeName: self.placeName,
+                     distance: Int(self.distance) ?? 0,
+                     addressName: self.addressName,
+                     categoryGroupCode: self.categoryGroupCode,
+                     categoryGroupName: self.categoryGroupName,
+                     categoryName: self.categoryName,
+                     id: self.id,
+                     phone: self.phone,
+                     placeUrl: self.placeUrl,
+                     longitude: self.longitude,
+                     latitude: self.latitude)
+    }
 }

--- a/SceneDepthPointCloud/Data/DTO/BuildingNearByGpsDTO.swift
+++ b/SceneDepthPointCloud/Data/DTO/BuildingNearByGpsDTO.swift
@@ -54,5 +54,4 @@ struct BuildingNearByGpsDocumentDTO: Decodable {
         case longitude = "x"
         case latitude = "y"
     }
-    
 }

--- a/SceneDepthPointCloud/Data/DTO/BuildingNearByGpsDTO.swift
+++ b/SceneDepthPointCloud/Data/DTO/BuildingNearByGpsDTO.swift
@@ -1,0 +1,58 @@
+//
+//  BuildingNearByGpsDTO.swift
+//  SceneDepthPointCloud
+//
+//  Created by Kang Minsang on 2023/04/24.
+//  Copyright © 2023 Apple. All rights reserved.
+//
+
+import Foundation
+
+/// BuildingApiService로부터 수신받은 Building 데이터 구조체
+struct BuildingNearByGpsDTO: Decodable {
+    let meta: BuildingNearByGpsMetaDTO
+    let documents: [BuildingNearByGpsDocumentDTO]
+}
+
+struct BuildingNearByGpsMetaDTO: Decodable {
+    let isEnd: Bool
+    let pageableCount: Int
+    let totalCount: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case isEnd = "is_end"
+        case pageableCount = "pageable_count"
+        case totalCount = "total_count"
+    }
+}
+
+struct BuildingNearByGpsDocumentDTO: Decodable {
+    let roadAddressName: String // 도로명주소
+    let placeName: String // 건물명
+    let distance: String // 거리(미터)
+    let addressName: String
+    let categoryGroupCode: String
+    let categoryGroupName: String
+    let categoryName: String
+    let id: String
+    let phone: String
+    let placeUrl: String
+    let longitude: String
+    let latitude: String
+    
+    enum CodingKeys: String, CodingKey {
+        case roadAddressName = "road_address_name"
+        case placeName = "place_name"
+        case distance = "distance"
+        case addressName = "address_name"
+        case categoryGroupCode = "category_group_code"
+        case categoryGroupName = "category_group_name"
+        case categoryName = "category_name"
+        case id = "id"
+        case phone = "phone"
+        case placeUrl = "place_url"
+        case longitude = "x"
+        case latitude = "y"
+    }
+    
+}

--- a/SceneDepthPointCloud/Data/Network/Network.swift
+++ b/SceneDepthPointCloud/Data/Network/Network.swift
@@ -37,7 +37,7 @@ struct Network {
     
     /// statusCode 값과 Data 값으로 NetworkResult 반환
     static func configurationNetworkResult(_ response: AFDataResponse<Data?>) -> NetworkResult {
-        print("Network Request: \(String(describing: response.request?.url))")
+//        print("Network Request: \(String(describing: response.request))")
         
         guard let statusCode = response.response?.statusCode else {
             print("Network Fail: No Status Code: \(String(describing: response.error?.localizedDescription))")

--- a/SceneDepthPointCloud/Data/Network/Network.swift
+++ b/SceneDepthPointCloud/Data/Network/Network.swift
@@ -37,7 +37,7 @@ struct Network {
     
     /// statusCode 값과 Data 값으로 NetworkResult 반환
     static func configurationNetworkResult(_ response: AFDataResponse<Data?>) -> NetworkResult {
-//        print("Network Request: \(String(describing: response.request))")
+        print("Network Request: \(String(describing: response.request))")
         
         guard let statusCode = response.response?.statusCode else {
             print("Network Fail: No Status Code: \(String(describing: response.error?.localizedDescription))")

--- a/SceneDepthPointCloud/Data/Network/NetworkInterceptor.swift
+++ b/SceneDepthPointCloud/Data/Network/NetworkInterceptor.swift
@@ -13,7 +13,6 @@ import Alamofire
 final class NetworkInterceptor: RequestInterceptor {
     /// KakaoApi를 사용하는 경우 Kakao Auth 를 추가 후 request 진행 설정
     func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
-        print("get in")
         guard urlRequest.url?.absoluteString.hasPrefix(NetworkURL.Domain.kakao) == true else {
             completion(.success(urlRequest))
             return
@@ -27,7 +26,7 @@ final class NetworkInterceptor: RequestInterceptor {
         
         var urlRequest = urlRequest
         urlRequest.setValue("KakaoAK \(kakaoApiAuth)", forHTTPHeaderField: "Authorization")
-        print("set header")
+        
         completion(.success(urlRequest))
     }
 }

--- a/SceneDepthPointCloud/Data/Network/NetworkURL.swift
+++ b/SceneDepthPointCloud/Data/Network/NetworkURL.swift
@@ -22,5 +22,6 @@ struct NetworkURL {
     
     enum Kakao {
         static let coordToAddress: String = Domain.kakao + "/v2/local/geo/coord2address.JSON"
+        static let searchByCategory: String = Domain.kakao + "/v2/local/search/category.JSON"
     }
 }

--- a/SceneDepthPointCloud/Data/Repository/AddressRepository.swift
+++ b/SceneDepthPointCloud/Data/Repository/AddressRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// 주소 정보 Repository
 final class AddressRepository: AddressRepositoryInterface {
-    /// AddressApiService로부터 AddressFromGpsDTO 를 받아 String 값만 반환하는 함수
+    /// AddressApiService로부터 AddressFromGpsDTO를 받아 String 값만 반환하는 함수
     func fetchAddress(from location: LocationData, completion: @escaping (Result<String, FetchError>) -> Void) {
         let endpoint = AddressApiService()
         

--- a/SceneDepthPointCloud/Data/Repository/BuildingRepository.swift
+++ b/SceneDepthPointCloud/Data/Repository/BuildingRepository.swift
@@ -1,0 +1,34 @@
+//
+//  BuildingRepository.swift
+//  SceneDepthPointCloud
+//
+//  Created by Kang Minsang on 2023/04/24.
+//  Copyright © 2023 Apple. All rights reserved.
+//
+
+import Foundation
+
+/// 건물 정보 Repository
+final class BuildingRepository: BuildingRepositoryInterface {
+    /// BuildingApiService로부터 BuildingNearByGpsDTO를 받아 [BuildingInfo]를 반환하는 함수
+    func fetchBuildingInfo(from location: LocationData, page: Int, completion: @escaping (Result<(infos: [BuildingInfo], isLastPage: Bool), FetchError>) -> Void) {
+        let endpoint = BuildingApiService()
+        
+        let x = Double(location.longitude)
+        let y = Double(location.latitude)
+        let page = page
+        
+        endpoint.getSearchByCategory(x: x, y: y, page: page) { result in
+            switch result {
+            case .success(let buildingDTO):
+                let infos = buildingDTO.documents.map { BuildingInfo(dto: $0) }
+                let isLastPage = buildingDTO.meta.isEnd
+                completion(.success((infos: infos, isLastPage: isLastPage)))
+                
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+        
+    }
+}

--- a/SceneDepthPointCloud/Data/Repository/BuildingRepository.swift
+++ b/SceneDepthPointCloud/Data/Repository/BuildingRepository.swift
@@ -21,7 +21,7 @@ final class BuildingRepository: BuildingRepositoryInterface {
         endpoint.getSearchByCategory(x: x, y: y, page: page) { result in
             switch result {
             case .success(let buildingDTO):
-                let infos = buildingDTO.documents.map { BuildingInfo(dto: $0) }
+                let infos = buildingDTO.documents.map { $0.toDomain() }
                 let isLastPage = buildingDTO.meta.isEnd
                 completion(.success((infos: infos, isLastPage: isLastPage)))
                 

--- a/SceneDepthPointCloud/Domain/Entity/BuildingInfo.swift
+++ b/SceneDepthPointCloud/Domain/Entity/BuildingInfo.swift
@@ -10,9 +10,9 @@ import Foundation
 
 /// Building 정보 데이터 구조체
 struct BuildingInfo {
-    let roadAddress: String
-    let placeName: String
-    let distance: Int
+    let roadAddress: String // 도로명주소
+    let placeName: String // 장소명(건물명)
+    let distance: Int // 거리(m단위)
     let addressName: String
     let categoryGroupCode: String
     let categoryGroupName: String

--- a/SceneDepthPointCloud/Domain/Entity/BuildingInfo.swift
+++ b/SceneDepthPointCloud/Domain/Entity/BuildingInfo.swift
@@ -1,0 +1,40 @@
+//
+//  BuildingInfo.swift
+//  SceneDepthPointCloud
+//
+//  Created by Kang Minsang on 2023/04/24.
+//  Copyright © 2023 Apple. All rights reserved.
+//
+
+import Foundation
+
+/// Building 정보 데이터 구조체
+struct BuildingInfo {
+    let roadAddress: String
+    let placeName: String
+    let distance: Int
+    let addressName: String
+    let categoryGroupCode: String
+    let categoryGroupName: String
+    let categoryName: String
+    let id: String
+    let phone: String
+    let placeUrl: String
+    let longitude: String
+    let latitude: String
+    
+    init(dto: BuildingNearByGpsDocumentDTO) {
+        self.roadAddress = dto.roadAddressName
+        self.placeName = dto.placeName
+        self.distance = Int(dto.distance) ?? 0
+        self.addressName = dto.addressName
+        self.categoryGroupCode = dto.categoryGroupCode
+        self.categoryGroupName = dto.categoryGroupName
+        self.categoryName = dto.categoryName
+        self.id = dto.id
+        self.phone = dto.phone
+        self.placeUrl = dto.placeUrl
+        self.longitude = dto.longitude
+        self.latitude = dto.latitude
+    }
+}

--- a/SceneDepthPointCloud/Domain/Entity/BuildingInfo.swift
+++ b/SceneDepthPointCloud/Domain/Entity/BuildingInfo.swift
@@ -10,6 +10,7 @@ import Foundation
 
 /// Building 정보 데이터 구조체
 struct BuildingInfo: Hashable {
+    let uuid = UUID()
     let roadAddress: String // 도로명주소
     let placeName: String // 장소명(건물명)
     let distance: Int // 거리(m단위)
@@ -24,6 +25,6 @@ struct BuildingInfo: Hashable {
     let latitude: String
     
     static func == (lhs: BuildingInfo, rhs: BuildingInfo) -> Bool {
-        return lhs.id == rhs.id
+        return lhs.uuid == rhs.uuid
     }
 }

--- a/SceneDepthPointCloud/Domain/Entity/BuildingInfo.swift
+++ b/SceneDepthPointCloud/Domain/Entity/BuildingInfo.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Building 정보 데이터 구조체
-struct BuildingInfo {
+struct BuildingInfo: Hashable {
     let roadAddress: String // 도로명주소
     let placeName: String // 장소명(건물명)
     let distance: Int // 거리(m단위)
@@ -23,18 +23,7 @@ struct BuildingInfo {
     let longitude: String
     let latitude: String
     
-    init(dto: BuildingNearByGpsDocumentDTO) {
-        self.roadAddress = dto.roadAddressName
-        self.placeName = dto.placeName
-        self.distance = Int(dto.distance) ?? 0
-        self.addressName = dto.addressName
-        self.categoryGroupCode = dto.categoryGroupCode
-        self.categoryGroupName = dto.categoryGroupName
-        self.categoryName = dto.categoryName
-        self.id = dto.id
-        self.phone = dto.phone
-        self.placeUrl = dto.placeUrl
-        self.longitude = dto.longitude
-        self.latitude = dto.latitude
+    static func == (lhs: BuildingInfo, rhs: BuildingInfo) -> Bool {
+        return lhs.id == rhs.id
     }
 }

--- a/SceneDepthPointCloud/Presentation/Extension/UIView+Extension.swift
+++ b/SceneDepthPointCloud/Presentation/Extension/UIView+Extension.swift
@@ -1,0 +1,31 @@
+//
+//  UIView+Extension.swift
+//  SceneDepthPointCloud
+//
+//  Created by Kang Minsang on 2023/04/24.
+//  Copyright © 2023 Apple. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    func fadeOut() {
+        UIView.animate(withDuration: 0.2) {
+            self.alpha = 0
+        }
+    }
+    
+    func fadeIn() {
+        UIView.animate(withDuration: 0.3) {
+            self.alpha = 1
+        }
+    }
+    
+    func disappear() {
+        self.alpha = 0
+    }
+    
+    func appear() {
+        self.alpha = 1
+    }
+}

--- a/SceneDepthPointCloud/Presentation/Main/MainVC.swift
+++ b/SceneDepthPointCloud/Presentation/Main/MainVC.swift
@@ -387,7 +387,8 @@ extension MainVC {
         
         if let vc = storyboard.instantiateViewController(identifier: SelectLocationVC.identifier) as? SelectLocationVC {
             let AddressRepository = AddressRepository()
-            let viewModel = SelectLocationVM(lidarData: lidarData, locationData: locationData, addressRepository: AddressRepository)
+            let buildingRepository = BuildingRepository()
+            let viewModel = SelectLocationVM(lidarData: lidarData, locationData: locationData, addressRepository: AddressRepository, buildingRepository: buildingRepository)
             // delegate 로 MainVC 전달
             vc.configureDelegate(self)
             // viewModel 로 측정된 liDarData, locationData 전달

--- a/SceneDepthPointCloud/Presentation/SelectLocation/Protocol/AddressRepositoryInterface.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/Protocol/AddressRepositoryInterface.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-/// Data Layer 을 간접접근하기 위한 인터페이스
+/// Data Layer를 간접접근하기 위한 인터페이스
 protocol AddressRepositoryInterface: AnyObject {
-    /// LocationData로부터 도로명주소를 수신하는 함수
+    /// LocationData로부터 도로명주소를 받는 함수
     func fetchAddress(from location: LocationData, completion: @escaping (Result<String, FetchError>) -> Void)
 }

--- a/SceneDepthPointCloud/Presentation/SelectLocation/Protocol/BuildingRepositoryInterface.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/Protocol/BuildingRepositoryInterface.swift
@@ -1,0 +1,15 @@
+//
+//  BuildingRepositoryInterface.swift
+//  SceneDepthPointCloud
+//
+//  Created by Kang Minsang on 2023/04/24.
+//  Copyright © 2023 Apple. All rights reserved.
+//
+
+import Foundation
+
+/// Data Layer를 간접접근하기 위한 인터페이스
+protocol BuildingRepositoryInterface: AnyObject {
+    /// LocationData로부터 100m근방 장소들을 받는 함수
+    func fetchBuildingInfo(from location: LocationData, completion: @escaping (Result<BuildingInfo, FetchError>) -> Void)
+}

--- a/SceneDepthPointCloud/Presentation/SelectLocation/Protocol/BuildingRepositoryInterface.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/Protocol/BuildingRepositoryInterface.swift
@@ -11,5 +11,5 @@ import Foundation
 /// Data Layer를 간접접근하기 위한 인터페이스
 protocol BuildingRepositoryInterface: AnyObject {
     /// LocationData로부터 100m근방 장소들을 받는 함수
-    func fetchBuildingInfo(from location: LocationData, completion: @escaping (Result<BuildingInfo, FetchError>) -> Void)
+    func fetchBuildingInfo(from location: LocationData, page: Int, completion: @escaping (Result<(infos: [BuildingInfo], isLastPage: Bool), FetchError>) -> Void)
 }

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
@@ -17,6 +17,8 @@ final class SelectLocationVC: UIViewController {
     private weak var delegate: SelectLocationDelegate?
     /// 화면 상단 타이틀 텍스트
     private let titleLabel = SelectLocationTitleLabel()
+    /// 뒤로가기 버튼
+    private let backButton = BackButton()
     /// 측정위치 선택 취소 및 창닫기 버튼
     private let cancelButton = CancelButton()
     /// 현재위치 기준 주소표시 텍스트
@@ -48,6 +50,17 @@ extension SelectLocationVC {
             self.titleLabel.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 20),
             self.titleLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
         ])
+        
+        // backButton
+        self.backButton.addAction(UIAction(handler: { [weak self] _ in
+            self?.viewModel?.prevMode()
+        }), for: .touchUpInside)
+        self.view.addSubview(self.backButton)
+        NSLayoutConstraint.activate([
+            self.backButton.centerYAnchor.constraint(equalTo: self.titleLabel.centerYAnchor),
+            self.backButton.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 20)
+        ])
+        self.backButton.isHidden = true
         
         // cancelButton
         self.cancelButton.addAction(UIAction(handler: { [weak self] _ in
@@ -145,6 +158,7 @@ extension SelectLocationVC {
     private func bindViewModel() {
         self.bindLocationData()
         self.bindNetworkError()
+        self.bindMode()
     }
     
     private func bindLocationData() {
@@ -163,6 +177,25 @@ extension SelectLocationVC {
             .sink(receiveValue: { [weak self] error in
                 guard let error = error else { return }
                 self?.showAlert(title: error.title, text: error.text)
+            })
+            .store(in: &self.cancellables)
+    }
+    
+    private func bindMode() {
+        self.viewModel?.$mode
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] mode in
+                switch mode {
+                case .selectLocation:
+                    print("asdefsadf")
+                    self?.backButton.isHidden = true
+                    // MARK: showMapView 필요
+                case .selectBuilding:
+                    print("selectBuilding")
+                    // MARK: showBuildingListView 필요
+                default:
+                    return
+                }
             })
             .store(in: &self.cancellables)
     }

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
@@ -280,4 +280,13 @@ extension SelectLocationVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         print("select")
     }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if self.buildingListView.contentOffset.y > (self.buildingListView.contentSize.height - self.buildingListView.bounds.size.height) {
+            guard self.viewModel?.fetching == false,
+                  self.viewModel?.isLastPage == false else { return }
+            
+            self.viewModel?.nextPageBuildingListFetch()
+        }
+    }
 }

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
@@ -25,6 +25,8 @@ final class SelectLocationVC: UIViewController {
     private let currentLocationLabel = RoadAddressLabel()
     /// 2D 지도 view
     private let mapView = MKMapView()
+    /// 주변 건물리스트표시 view
+    private let buildingListView = UICollectionView()
     /// 선택 및 데이터 업로드 버튼
     private let bottomButton = SelectLocationLargeButton()
     /// 측정위치 선택화면 관련된 로직담당 객체
@@ -112,6 +114,8 @@ extension SelectLocationVC {
             pinShadow.centerXAnchor.constraint(equalTo: centerPin.centerXAnchor),
             pinShadow.centerYAnchor.constraint(equalTo: centerPin.bottomAnchor)
         ])
+        
+        self.mapView.isHidden = true
         
         // bottomButton
         self.bottomButton.addAction(UIAction(handler: { [weak self] _ in

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
@@ -38,6 +38,7 @@ final class SelectLocationVC: UIViewController {
         super.viewDidLoad()
         self.configureUI()
         self.configureMapView()
+        self.configureBuildingListView()
         self.bindViewModel()
     }
 }
@@ -144,6 +145,10 @@ extension SelectLocationVC {
         
         self.mapView.delegate = self
     }
+    
+    private func configureBuildingListView() {
+        self.buildingListView.delegate = self
+    }
 }
 
 // MARK: INPUT from MainVC
@@ -210,5 +215,21 @@ extension SelectLocationVC: MKMapViewDelegate {
         // mapView 의 중심좌표로 locationData 를 업데이트 한다
         let center = mapView.centerCoordinate
         self.viewModel?.updateLocation(to: center)
+    }
+}
+
+extension SelectLocationVC: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        return UICollectionViewCell.init()
+    }
+}
+
+extension SelectLocationVC: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print("select")
     }
 }

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
@@ -160,14 +160,14 @@ extension SelectLocationVC {
         self.mapView.showsCompass = true
         
         self.mapView.delegate = self
-        self.mapView.isHidden = true
+        self.mapView.alpha = 0
     }
     
     private func configureBuildingListView() {
         self.buildingListView.backgroundColor = .clear
         self.buildingListView.register(BuildingListCollectionViewCell.self, forCellWithReuseIdentifier: BuildingListCollectionViewCell.identifier)
         self.buildingListView.delegate = self
-        self.buildingListView.isHidden = true
+        self.buildingListView.alpha = 0
     }
     
     private func configureBuildingListDataSource() {
@@ -230,16 +230,16 @@ extension SelectLocationVC {
                 case .selectLocation:
                     self?.backButton.isHidden = true
                     self?.titleLabel.changeText(to: .selectLocation)
-                    self?.mapView.isHidden = false
+                    self?.mapView.fadeIn()
                     self?.mapView.isScrollEnabled = true
-                    self?.buildingListView.isHidden = true
+                    self?.buildingListView.fadeOut()
                     self?.bottomButton.changeStatus(to: .selectable)
                 case .selectBuilding:
                     self?.backButton.isHidden = false
                     self?.titleLabel.changeText(to: .selectBuilding)
-                    self?.mapView.isHidden = true
+                    self?.mapView.disappear()
                     self?.mapView.isScrollEnabled = false
-                    self?.buildingListView.isHidden = false
+                    self?.buildingListView.fadeIn()
                     self?.bottomButton.changeStatus(to: .beforeSetting)
                 default:
                     return

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
@@ -128,7 +128,7 @@ extension SelectLocationVC {
     /// mapView 화면을 표시할 초기화 함수
     private func configureMapView() {
         guard let locationData = self.viewModel?.locationData else { return }
-        print("측정 위치: \(locationData.latitude), \(locationData.longitude)")
+        
         let latitude = locationData.latitude
         let longitude = locationData.longitude
         let region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: latitude, longitude: longitude), span: .init(latitudeDelta: 0.002, longitudeDelta: 0.002))
@@ -187,7 +187,6 @@ extension SelectLocationVC {
             .sink(receiveValue: { [weak self] mode in
                 switch mode {
                 case .selectLocation:
-                    print("asdefsadf")
                     self?.backButton.isHidden = true
                     // MARK: showMapView 필요
                 case .selectBuilding:

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
@@ -12,12 +12,22 @@ import CoreLocation
 
 /// 측정위치 선택화면의 View 를 나타내기 위한 데이터 처리 담당
 final class SelectLocationVM {
+    enum Mode {
+        case selectLocation
+        case selectBuilding
+        case setIndoorInfo
+        case done
+    }
     /// MainVM 에서 생성된 lidarData 값
     let lidarData: LiDARData
     /// MainVM 에서 생성된 locationData 값 및 사용자설정 위치값
     @Published private(set) var locationData: LocationData
+    /// 위치선택, 건물선택, 건물선택 완료 상태값
+    @Published private(set) var mode: Mode = .selectLocation
     /// 네트워크 통신으로 인한 Error 발생값
     @Published private(set) var networkError: (title: String, text: String)?
+    /// 건물리스트 api 사용시 pagenation 을 위한 현재 page 값
+    private var page: Int = 1
     /// Address 데이터를 담당하는 객체
     private let addressRepository: AddressRepositoryInterface
     
@@ -58,7 +68,19 @@ extension SelectLocationVM {
     
     /// 현재 mode 값에 따라 다음 mode 값으로 변경하는 함수
     func changeMode() {
-        print("change mode")
-        // MARK: mode 값 변경 로직 필요
+        switch self.mode {
+        case .selectLocation:
+            self.mode = .selectBuilding
+            self.page = 1
+            self.fetchBuildingList()
+        default:
+            return
+        }
+    }
+}
+
+extension SelectLocationVM {
+    private func fetchBuildingList() {
+        // MARK: page 값을 통해 buildingList 수신
     }
 }

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
@@ -22,19 +22,26 @@ final class SelectLocationVM {
     let lidarData: LiDARData
     /// MainVM 에서 생성된 locationData 값 및 사용자설정 위치값
     @Published private(set) var locationData: LocationData
+    /// 주변 건물리스트
+    @Published private(set) var buildingList: [BuildingInfo] = []
     /// 위치선택, 건물선택, 건물선택 완료 상태값
     @Published private(set) var mode: Mode = .selectLocation
     /// 네트워크 통신으로 인한 Error 발생값
     @Published private(set) var networkError: (title: String, text: String)?
     /// 건물리스트 api 사용시 pagenation 을 위한 현재 page 값
     private var page: Int = 1
+    /// pagenation 불가능 여부값
+    private var isLastPage: Bool = false
     /// Address 데이터를 담당하는 객체
     private let addressRepository: AddressRepositoryInterface
+    /// BuildingInfo 데이터를 담당하는 객체
+    private let buildingRepository: BuildingRepositoryInterface
     
-    init(lidarData: LiDARData, locationData: LocationData, addressRepository: AddressRepositoryInterface) {
+    init(lidarData: LiDARData, locationData: LocationData, addressRepository: AddressRepositoryInterface, buildingRepository: BuildingRepositoryInterface) {
         self.lidarData = lidarData
         self.locationData = locationData
         self.addressRepository = addressRepository
+        self.buildingRepository = buildingRepository
         
         self.updateLocation()
     }
@@ -66,12 +73,21 @@ extension SelectLocationVM {
         }
     }
     
+    /// page 값 증가 후 fetchBuildingList() 함수 호출하는 함수
+    func nextPageBuildingListFetch() {
+        guard self.isLastPage == false else { return }
+        
+        self.page += 1
+        self.fetchBuildingList()
+    }
+    
     /// 현재 mode 값에 따라 다음 mode 값으로 변경하는 함수
     func changeMode() {
         switch self.mode {
         case .selectLocation:
             self.mode = .selectBuilding
             self.page = 1
+            self.isLastPage = false
             self.fetchBuildingList()
         default:
             return
@@ -85,7 +101,24 @@ extension SelectLocationVM {
 }
 
 extension SelectLocationVM {
+    /// locationData 값을 토대로 getBuildingList() 함수호출을 통해 buildingList 배열에 추가하는 함수
     private func fetchBuildingList() {
-        // MARK: page 값을 통해 buildingList 수신
+        guard self.isLastPage == false else { return }
+        
+        let locationData = self.locationData
+        let page = self.page
+        
+        DispatchQueue.global().async { [weak self] in
+            self?.buildingRepository.fetchBuildingInfo(from: locationData, page: page, completion: { [weak self] result in
+                switch result {
+                case .success((let infos, let isLastPage)):
+                    self?.buildingList += infos
+                    self?.isLastPage = isLastPage
+                    
+                case .failure(let fetchError):
+                    self?.networkError = (title: "Fetch BuildingList Error", text: fetchError.message)
+                }
+            })
+        }
     }
 }

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
@@ -77,6 +77,11 @@ extension SelectLocationVM {
             return
         }
     }
+    
+    /// 뒤로가기 버튼으로 인한 mode값 변경
+    func prevMode() {
+        
+    }
 }
 
 extension SelectLocationVM {

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
@@ -96,7 +96,15 @@ extension SelectLocationVM {
     
     /// 뒤로가기 버튼으로 인한 mode값 변경
     func prevMode() {
-        
+        switch self.mode {
+        case .selectLocation:
+            return
+        case .selectBuilding:
+            self.buildingList = []
+            self.mode = .selectLocation
+        default:
+            return
+        }
     }
 }
 

--- a/SceneDepthPointCloud/Presentation/SelectLocation/View/BackButton.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/View/BackButton.swift
@@ -1,15 +1,15 @@
 //
-//  CancelButton.swift
+//  BackButton.swift
 //  SceneDepthPointCloud
 //
-//  Created by Kang Minsang on 2023/04/21.
+//  Created by Kang Minsang on 2023/04/24.
 //  Copyright © 2023 Apple. All rights reserved.
 //
 
 import UIKit
 
-/// SelectLocationVC의 우상단 취소버튼 커스텀뷰
-final class CancelButton: UIButton {
+/// SelectLocationVC의 좌상단 뒤로가기 커스텀뷰
+final class BackButton: UIButton {
     convenience init() {
         self.init(frame: CGRect())
         self.configure()
@@ -17,8 +17,8 @@ final class CancelButton: UIButton {
     
     private func configure() {
         self.translatesAutoresizingMaskIntoConstraints = false
-        self.setImage(UIImage.init(systemName: "xmark"), for: .normal)
-        self.setPreferredSymbolConfiguration(.init(pointSize: 18, weight: .regular, scale: .large), forImageIn: .normal)
+        self.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+        self.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration(pointSize: 18, weight: .regular, scale: .large), forImageIn: .normal)
         self.tintColor = .white
         
         NSLayoutConstraint.activate([

--- a/SceneDepthPointCloud/Presentation/SelectLocation/View/BackButton.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/View/BackButton.swift
@@ -20,6 +20,7 @@ final class BackButton: UIButton {
         self.setImage(UIImage(systemName: "chevron.left"), for: .normal)
         self.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration(pointSize: 18, weight: .regular, scale: .large), forImageIn: .normal)
         self.tintColor = .white
+        self.contentMode = .scaleAspectFit
         
         NSLayoutConstraint.activate([
             self.widthAnchor.constraint(equalToConstant: 22),

--- a/SceneDepthPointCloud/Presentation/SelectLocation/View/BuildingListCellCollectionViewCell.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/View/BuildingListCellCollectionViewCell.swift
@@ -1,0 +1,91 @@
+//
+//  BuildingListCellCollectionViewCell.swift
+//  SceneDepthPointCloud
+//
+//  Created by Kang Minsang on 2023/04/24.
+//  Copyright © 2023 Apple. All rights reserved.
+//
+
+import UIKit
+
+/// BuildingListView 에서 표시되는 Cell
+final class BuildingListCellCollectionViewCell: UICollectionViewCell {
+    static let identifier = "BuildingListCellCollectionViewCell"
+    private var buildingNameLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .white
+        label.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
+        label.textAlignment = .left
+        return label
+    }()
+    private var roadAddressLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .white
+        label.font = UIFont.systemFont(ofSize: 11, weight: .regular)
+        label.textAlignment = .left
+        return label
+    }()
+    private var distanceLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .white
+        label.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
+        label.textAlignment = .right
+        return label
+    }()
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configure()
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        self.configure()
+    }
+    
+    override func prepareForReuse() {
+        self.backgroundColor = UIColor(named: "buildingCellBackgroundColor")
+    }
+    
+    private func configure() {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        
+        let stackView = UIStackView(arrangedSubviews: [self.buildingNameLabel, self.roadAddressLabel])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 2
+        stackView.alignment = .leading
+        
+        self.addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: self.topAnchor, constant: 8),
+            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 12),
+            stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -8)
+        ])
+        
+        self.addSubview(self.distanceLabel)
+        NSLayoutConstraint.activate([
+            self.distanceLabel.widthAnchor.constraint(equalToConstant: 50),
+            self.distanceLabel.centerYAnchor.constraint(equalTo: self.buildingNameLabel.centerYAnchor),
+            self.distanceLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -12),
+            self.distanceLabel.leadingAnchor.constraint(equalTo: stackView.trailingAnchor, constant: 12)
+        ])
+    }
+}
+
+// MARK: INPUT
+extension BuildingListCellCollectionViewCell {
+    /// cell 내용설정 함수
+    func updateCell(info: BuildingInfo, isSelected: Bool) {
+        self.buildingNameLabel.text = info.placeName
+        self.roadAddressLabel.text = info.roadAddress
+        self.distanceLabel.text = "\(info.distance) M"
+        
+        if isSelected {
+            self.backgroundColor = UIColor(named: "mainColor")
+        }
+    }
+}

--- a/SceneDepthPointCloud/Presentation/SelectLocation/View/BuildingListCollectionViewCell.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/View/BuildingListCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  BuildingListCellCollectionViewCell.swift
+//  BuildingListCollectionViewCell.swift
 //  SceneDepthPointCloud
 //
 //  Created by Kang Minsang on 2023/04/24.
@@ -9,8 +9,12 @@
 import UIKit
 
 /// BuildingListView 에서 표시되는 Cell
-final class BuildingListCellCollectionViewCell: UICollectionViewCell {
-    static let identifier = "BuildingListCellCollectionViewCell"
+final class BuildingListCollectionViewCell: UICollectionViewCell {
+    static let identifier = "BuildingListCollectionViewCell"
+    enum Section: CaseIterable {
+        case main
+    }
+    
     private var buildingNameLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -73,11 +77,15 @@ final class BuildingListCellCollectionViewCell: UICollectionViewCell {
             self.distanceLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -12),
             self.distanceLabel.leadingAnchor.constraint(equalTo: stackView.trailingAnchor, constant: 12)
         ])
+        
+        self.backgroundColor = UIColor(named: "buildingCellBackgroundColor")
+        self.layer.cornerRadius = 8
+        self.layer.cornerCurve = .continuous
     }
 }
 
 // MARK: INPUT
-extension BuildingListCellCollectionViewCell {
+extension BuildingListCollectionViewCell {
     /// cell 내용설정 함수
     func updateCell(info: BuildingInfo, isSelected: Bool) {
         self.buildingNameLabel.text = info.placeName

--- a/SceneDepthPointCloud/Presentation/SelectLocation/View/SelectLocationLargeButton.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/View/SelectLocationLargeButton.swift
@@ -42,12 +42,15 @@ final class SelectLocationLargeButton: UIButton {
         case .selectable:
             self.setTitle("선택 완료", for: .normal)
             self.isUserInteractionEnabled = true
+            self.backgroundColor = UIColor(named: "mainColor")
         case .beforeSetting:
             self.setTitle("데이터 업로드", for: .normal)
             self.isUserInteractionEnabled = false
+            self.backgroundColor = UIColor(named: "deActivateMainColor")
         case .uploadable:
             self.setTitle("데이터 업로드", for: .normal)
             self.isUserInteractionEnabled = true
+            self.backgroundColor = UIColor(named: "mainColor")
         }
     }
 }


### PR DESCRIPTION
## 개요
- Issue: #11
- SFR
    - [SFR-017](https://github.com/FreeDeveloper97/point-cloud-with-lidar/wiki/Requirements#sfr-017)
- URF
    - [UFR-APP-003](https://github.com/FreeDeveloper97/point-cloud-with-lidar/wiki/Requirements#ufr-app-003)
- UI
    - [UI-A-005](https://github.com/FreeDeveloper97/point-cloud-with-lidar/wiki/Interfaces#ui-a-005)

## 변경사항

### Issue Checklist
- [x] VM: mode 값
- [x] VM: changeMode() 구현
- [x] BuildingNearByGpsDTO 생성
- [x] BuildingInfo 생성
- [x] BuildingApiService 생성
- [x] BuildingRepositoryInterface 생성
- [x] BuildingRepository 생성
- [x] VM: page 값
- [x] VM: buildingList 값
- [x] fetchBuildingList() 구현
- [x] nextPageBuildingListFetch() 구현
- [x] buildingListView 생성
- [x] bindMode() 구현
- [x] bindBuildingList() 구현
- [x] backButton 생성

### BuildingRepositoryInterface
SelectLocationVM 에서 건물정보를 받아오기 위해서 `SelectLocaionVM -> BuildingRepository` 식으로 접근한다.
`Clean Architecture`에 따라 ViewModel에서 직접적으로 네트워크에 접근이 아닌 Building 정보를 관리하는 `BuildingRepository`를 접근하는 식으로 구현하였다.

다만 Clean Architecture 상 Domain Layer 인 `UseCase` 가 필요하지만 `단순 CRUD를 하는 기능의 경우 불필요하다`는 판단으로 `ViewModel -> Repository`로 접근하는 식으로 구현하였다.

다만 서로 다른 Layer로 접근하기 때문에 Protocol 인 `RepositoryInterface`를 통해 직접접근이 아닌 간접접근 형식으로 구현하였다.
```swift
/// Data Layer를 간접접근하기 위한 인터페이스
protocol BuildingRepositoryInterface: AnyObject {
    /// LocationData로부터 100m근방 장소들을 받는 함수
    func fetchBuildingInfo(from location: LocationData, page: Int, completion: @escaping (Result<(infos: [BuildingInfo], isLastPage: Bool), FetchError>) -> Void)
}
```
### BuildingRepository
건물 정보를 반환하는 `Repository` 담당 객체이며, `BuildingRepositoryInterface`를 채택하여 구현한 객체이다.
Repository 내에서는 필요한 데이터를 앱 내부 저장소인 `LocalDB` 접근과 `Network` 통신으로 인한 접근 방식을 사용하여 데이터를 반환해야 한다.

건물 정보의 경우 KakaoAPI를 통해 데이터를 수신하기 때문에 `endpoint` 값을 `Network`에서 데이터를 받아오는 로직으로 구현하였다.

정보를 항상 성공적으로 수신할수는 없으며, 에러상황이 발생한 경우 어떤 에러상황인지를 UI상으로 표시하기 위해서 `Result<(infos: [BuildingInfo], isLastPage: Bool), FetchError>` 값으로 실패의 경우의 Error 값을 같이 반환하는 식으로 구현하였다.

`fetchBuildingInfo` 함수는 DTO 내에서 건물정보들을 `BuildingInfo` 구조체로 변환된 `[BuildingInfo]` 값과 pagenation의 마지막 페이지인지 여부 값인 `Bool` 값을 반환하도록 구현하였다.
```swift
/// 건물 정보 Repository
final class BuildingRepository: BuildingRepositoryInterface {
    /// BuildingApiService로부터 BuildingNearByGpsDTO를 받아 [BuildingInfo]를 반환하는 함수
    func fetchBuildingInfo(from location: LocationData, page: Int, completion: @escaping (Result<(infos: [BuildingInfo], isLastPage: Bool), FetchError>) -> Void) {
        let endpoint = BuildingApiService()
        
        let x = Double(location.longitude)
        let y = Double(location.latitude)
        let page = page
        
        endpoint.getSearchByCategory(x: x, y: y, page: page) { result in
            switch result {
            case .success(let buildingDTO):
                let infos = buildingDTO.documents.map { $0.toDomain() }
                let isLastPage = buildingDTO.meta.isEnd
                completion(.success((infos: infos, isLastPage: isLastPage)))
                
            case .failure(let error):
                completion(.failure(error))
            }
        }
        
    }
}
```

### KakaoAPI 연결
`BuildingRepository`에서 `Network`를 통해 주소를 반환하기 위해서 KakaoAPI를 사용하였다.
[Kakao API: Search by category](https://developers.kakao.com/docs/latest/ko/local/dev-guide#search-by-category) 기반으로 NetworkURL내 KakaoAPI 의 URL 주소를 저장하였고, 데이터를 수신받기 위한 `BuildingNearByGpsDTO` 구조체를 생성하였다.

DTO 내에는 Domain Layer 및 프로젝트에서 사용되기 위한 `Entity`로 반환하는 ``.toDomain()`` 함수를 추가하였다.
```swift
/// BuildingApiService로부터 수신받은 Building 데이터 구조체
struct BuildingNearByGpsDTO: Decodable {
    let meta: BuildingNearByGpsMetaDTO
    let documents: [BuildingNearByGpsDocumentDTO]
}

struct BuildingNearByGpsMetaDTO: Decodable {
    let isEnd: Bool
    let pageableCount: Int
    let totalCount: Int
    
    enum CodingKeys: String, CodingKey {
        case isEnd = "is_end"
        case pageableCount = "pageable_count"
        case totalCount = "total_count"
    }
}

struct BuildingNearByGpsDocumentDTO: Decodable {
    let roadAddressName: String // 도로명주소
    let placeName: String // 건물명
    let distance: String // 거리(미터)
    let addressName: String
    let categoryGroupCode: String
    let categoryGroupName: String
    let categoryName: String
    let id: String
    let phone: String
    let placeUrl: String
    let longitude: String
    let latitude: String
    
    enum CodingKeys: String, CodingKey {
        case roadAddressName = "road_address_name"
        case placeName = "place_name"
        case distance = "distance"
        case addressName = "address_name"
        case categoryGroupCode = "category_group_code"
        case categoryGroupName = "category_group_name"
        case categoryName = "category_name"
        case id = "id"
        case phone = "phone"
        case placeUrl = "place_url"
        case longitude = "x"
        case latitude = "y"
    }
    
    func toDomain() -> BuildingInfo {
        return .init(roadAddress: self.addressName,
                     placeName: self.placeName,
                     distance: Int(self.distance) ?? 0,
                     addressName: self.addressName,
                     categoryGroupCode: self.categoryGroupCode,
                     categoryGroupName: self.categoryGroupName,
                     categoryName: self.categoryName,
                     id: self.id,
                     phone: self.phone,
                     placeUrl: self.placeUrl,
                     longitude: self.longitude,
                     latitude: self.latitude)
    }
}
```

### BuildingInfo
`BuildingRepository`에서 `BuildingApiService`를 통해 `BuildingNearByGpsDTO` 구조체를 수신받아 ViewModel로 반환하기 위하여 `BuildingInfo` 구조체로 변환 후 반환된다.
변환 과정은 DTO.toDomain() 함수를 통해 반환된다.

해당 데이터 구조체는 건물 데이터를 담당하는 구조체이며, UI단에서 DataSource로 사용되기 위하여 Hashable 값을 채택하였다.
혹시라도 동일한 데이터가 수신될 경우를 방지가히 위하여 hash 값을 uuid 값을 기준으로 설정하였다.
```swift
/// Building 정보 데이터 구조체
struct BuildingInfo: Hashable {
    let uuid = UUID()
    let roadAddress: String // 도로명주소
    let placeName: String // 장소명(건물명)
    let distance: Int // 거리(m단위)
    let addressName: String
    let categoryGroupCode: String
    let categoryGroupName: String
    let categoryName: String
    let id: String
    let phone: String
    let placeUrl: String
    let longitude: String
    let latitude: String
    
    static func == (lhs: BuildingInfo, rhs: BuildingInfo) -> Bool {
        return lhs.uuid == rhs.uuid
    }
}
```

### SelectLocationVM
`SelectLocationVM` 에서 `BuildingRepositoryInterface`로 간접접근을 통해 주변 건물정보들을 수신받을 수 있고, 성공, 실패에 따라 실패의 경우 UI적으로 어떤오류 상태인지 표시할 수 있도록 구현하였다.
수신을 성공한 경우 기존 buildingList 배열에 추가되어 UI로 표시된다.
```swift
/// locationData 값을 토대로 getBuildingList() 함수호출을 통해 buildingList 배열에 추가하는 함수
private func fetchBuildingList() {
    guard self.fetching == false,
          self.isLastPage == false else { return }

    self.fetching = true
    let locationData = self.locationData
    let page = self.page

    DispatchQueue.global().async { [weak self] in
        self?.buildingRepository.fetchBuildingInfo(from: locationData, page: page, completion: { [weak self] result in
            switch result {
            case .success((let infos, let isLastPage)):
                self?.buildingList += infos
                self?.isLastPage = isLastPage

            case .failure(let fetchError):
                self?.networkError = (title: "Fetch BuildingList Error", text: fetchError.message)
            }
            self?.fetching = false
        })
    }
}
```

### DiffableDataSource
iOS단에서 스크롤을 통해 여러가지 동일한 Cell로 표시하는 방법은 UICollectionView, UITableView 방법이 있다.
이중 확장성을 고려하여 [UICollectionView](https://developer.apple.com/documentation/uikit/uicollectionview)를 채택하였다.

UICollectionView를 표시하기 위한 DataSource를 설정하는 방법으로 ViewController 에서 기존 [UICollectionViewDataSource](https://developer.apple.com/documentation/uikit/uicollectionviewdatasource)를 채택하여 제공하는 방법이 있었으나, 이번기회에 iOS13부터 새롭게 제공된 [UICollectionViewDiffableDataSource](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource) 방식으로 구현하였다.

해당 방식은 cell 데이터가 변경되었을 때 부드러운 애니메이션을 제공할 수 있다는 점에서 시도해볼 가치를 느꼈다.

애플에서 제공한 샘플 [Implementing Modern Collection Views](https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/implementing_modern_collection_views) 프로젝트 코드를 기반으로 작성하였다.
```swift
private var buildingListDataSource: UICollectionViewDiffableDataSource<BuildingListCollectionViewCell.Section, BuildingInfo>!
```
```swift
private func configureBuildingListDataSource() {
    let cellRegistration = UICollectionView.CellRegistration<BuildingListCollectionViewCell, BuildingInfo> { (cell, indexPath, info) in
        let isSelected = self.viewModel?.mode == .setIndoorInfo
        cell.updateCell(info: info, isSelected: isSelected)
    }

    self.buildingListDataSource = UICollectionViewDiffableDataSource<BuildingListCollectionViewCell.Section, BuildingInfo>(collectionView: self.buildingListView) { (collectionView: UICollectionView, indexPath: IndexPath, identifier: BuildingInfo) -> UICollectionViewCell? in
        return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: identifier)
    }
}
```

SelectLocationVM 내 있는 buildingList 값이 변동됨을 ViewController 에서 수신받아 DataSource를 업데이트 한다.
```swift
private func bindBuildingList() {
    self.viewModel?.$buildingList
        .receive(on: DispatchQueue.main)
        .sink(receiveValue: { [weak self] buildingList in
            var snapshot = NSDiffableDataSourceSnapshot<BuildingListCollectionViewCell.Section, BuildingInfo>()
            snapshot.appendSections([.main])
            snapshot.appendItems(buildingList)
            self?.buildingListDataSource.apply(snapshot, animatingDifferences: true)
        })
        .store(in: &self.cancellables)
}
```

### 스크린샷
| SelectLocationVC 건물 선택 화면 | 위치 선택 -> 건물 선택 |
| -------- | -------- |
| <img src="https://i.imgur.com/jLhjbh7.png"> | <img src="https://i.imgur.com/HvW19pB.gif"> |

### 추가 팀 논의사항
- 건물 층 개념
    - 나라별로 층의 개념들이 각기 다름을 인지
    - 단순 Int형으로 불가능할 것 같다는 것으로 인지
    - [국가별 지상 지하층 표기방식 블로그](https://m.blog.naver.com/khd9345/221600763193) 내용을 토대로 String 타입으로 고민중

## 레퍼런스
- [UICollectionViewCell programmatically 블로그](https://velog.io/@panther222128/UICollectionView-Programmatically-Practice)
- [UICollectionView layout 블로그](https://youbidan-project.tistory.com/99)
- [UICollectionView Pagination 블로그](https://velog.io/@mmim/iOS-CollectionView-TableView-Paginationfeat.-ContentOffSet-ContentSize)

---

- [UICollectionView](https://developer.apple.com/documentation/uikit/uicollectionview)
- [UICollectionViewDataSource](https://developer.apple.com/documentation/uikit/uicollectionviewdatasource)
- [UICollectionViewDiffableDataSource](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource)
- [WWDC2019: Advances in UI Data Sources](https://developer.apple.com/videos/play/wwdc2019/220/)
- [Implementing Modern Collection Views](https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/implementing_modern_collection_views)
- [Diffable Datasource 블로그](https://zeddios.tistory.com/1197)
- [Diffable Datasource - supplied item identifiers are not unique 블로그](https://zeddios.tistory.com/1241)


---

- [국가별 지상 지하층 표기방식 블로그](https://m.blog.naver.com/khd9345/221600763193)