### PR TITLE
SelectLocationVC 실내 위치 설정 화면

### DIFF
--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		8711C71429D131A200F6D5CC /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 8711C71329D131A200F6D5CC /* Alamofire */; };
 		872C7A9E29F1332B002D91D2 /* LocationUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872C7A9D29F1332B002D91D2 /* LocationUsecase.swift */; };
 		8749E16A29EEE2940093F7A7 /* PointCloudCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8749E16929EEE2940093F7A7 /* PointCloudCountView.swift */; };
+		87673BD429F80E0500BD3DC3 /* IndoorSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87673BD329F80E0500BD3DC3 /* IndoorSettingView.swift */; };
 		877F533B29F62E2300A0F931 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533A29F62E2300A0F931 /* BackButton.swift */; };
 		877F533D29F6328D00A0F931 /* BuildingNearByGpsDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533C29F6328D00A0F931 /* BuildingNearByGpsDTO.swift */; };
 		877F533F29F63E1F00A0F931 /* BuildingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F533E29F63E1F00A0F931 /* BuildingInfo.swift */; };
@@ -59,6 +60,7 @@
 /* Begin PBXFileReference section */
 		872C7A9D29F1332B002D91D2 /* LocationUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationUsecase.swift; sourceTree = "<group>"; };
 		8749E16929EEE2940093F7A7 /* PointCloudCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointCloudCountView.swift; sourceTree = "<group>"; };
+		87673BD329F80E0500BD3DC3 /* IndoorSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndoorSettingView.swift; sourceTree = "<group>"; };
 		877F533A29F62E2300A0F931 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		877F533C29F6328D00A0F931 /* BuildingNearByGpsDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingNearByGpsDTO.swift; sourceTree = "<group>"; };
 		877F533E29F63E1F00A0F931 /* BuildingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingInfo.swift; sourceTree = "<group>"; };
@@ -261,6 +263,7 @@
 				87C8FB1629F28F8A000C37CE /* SelectLocationLargeButton.swift */,
 				877F533A29F62E2300A0F931 /* BackButton.swift */,
 				877F534829F666AF00A0F931 /* BuildingListCollectionViewCell.swift */,
+				87673BD329F80E0500BD3DC3 /* IndoorSettingView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -442,6 +445,7 @@
 				8793524F29B9D8F200D6A079 /* Utils.swift in Sources */,
 				87ABC86C29D290E900881FFB /* RecordingButton.swift in Sources */,
 				87C8FB0A29F23717000C37CE /* AddressRepository.swift in Sources */,
+				87673BD429F80E0500BD3DC3 /* IndoorSettingView.swift in Sources */,
 				87C8FAFB29F1867E000C37CE /* SelectLocationVM.swift in Sources */,
 				877F534329F642EC00A0F931 /* BuildingRepositoryInterface.swift in Sources */,
 				E73DD13624636FEF00D77039 /* Renderer.swift in Sources */,

--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		877F534529F643B600A0F931 /* BuildingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534429F643B600A0F931 /* BuildingRepository.swift */; };
 		877F534929F666AF00A0F931 /* BuildingListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534829F666AF00A0F931 /* BuildingListCollectionViewCell.swift */; };
 		877F534B29F69D1600A0F931 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534A29F69D1600A0F931 /* UIView+Extension.swift */; };
+		877F534D29F7C46600A0F931 /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877F534C29F7C46600A0F931 /* Collection+Extension.swift */; };
 		8793524F29B9D8F200D6A079 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793524E29B9D8F200D6A079 /* Utils.swift */; };
 		87ABC85B29D175A700881FFB /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85A29D175A700881FFB /* Network.swift */; };
 		87ABC85D29D176C700881FFB /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ABC85C29D176C700881FFB /* NetworkResult.swift */; };
@@ -66,6 +67,7 @@
 		877F534429F643B600A0F931 /* BuildingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingRepository.swift; sourceTree = "<group>"; };
 		877F534829F666AF00A0F931 /* BuildingListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingListCollectionViewCell.swift; sourceTree = "<group>"; };
 		877F534A29F69D1600A0F931 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
+		877F534C29F7C46600A0F931 /* Collection+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extension.swift"; sourceTree = "<group>"; };
 		8793524E29B9D8F200D6A079 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		87ABC85929D173BC00881FFB /* env.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = env.xcconfig; sourceTree = "<group>"; };
 		87ABC85A29D175A700881FFB /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
@@ -213,6 +215,7 @@
 			children = (
 				87ABC86629D1946400881FFB /* UIViewController+Extension.swift */,
 				877F534A29F69D1600A0F931 /* UIView+Extension.swift */,
+				877F534C29F7C46600A0F931 /* Collection+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -445,6 +448,7 @@
 				877F533D29F6328D00A0F931 /* BuildingNearByGpsDTO.swift in Sources */,
 				E73DD13824636FEF00D77039 /* MainVC.swift in Sources */,
 				87ABC87129D30EE000881FFB /* MeasuredData.swift in Sources */,
+				877F534D29F7C46600A0F931 /* Collection+Extension.swift in Sources */,
 				877F534B29F69D1600A0F931 /* UIView+Extension.swift in Sources */,
 				87C8FAF929F171D1000C37CE /* SelectLocationVC.swift in Sources */,
 				87ABC85F29D176F700881FFB /* NetworkStatus.swift in Sources */,
@@ -602,7 +606,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				INFOPLIST_FILE = SceneDepthPointCloud/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Point Cloud";
@@ -630,7 +634,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				INFOPLIST_FILE = SceneDepthPointCloud/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Point Cloud";

--- a/SceneDepthPointCloud/Domain/Entity/BuildingInfo.swift
+++ b/SceneDepthPointCloud/Domain/Entity/BuildingInfo.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Building 정보 데이터 구조체
 struct BuildingInfo: Hashable {
-    let uuid = UUID()
+    var uuid = UUID()
     let roadAddress: String // 도로명주소
     let placeName: String // 장소명(건물명)
     let distance: Int // 거리(m단위)
@@ -26,5 +26,9 @@ struct BuildingInfo: Hashable {
     
     static func == (lhs: BuildingInfo, rhs: BuildingInfo) -> Bool {
         return lhs.uuid == rhs.uuid
+    }
+    
+    mutating func updateUUID() {
+        self.uuid = UUID()
     }
 }

--- a/SceneDepthPointCloud/Presentation/Extension/Collection+Extension.swift
+++ b/SceneDepthPointCloud/Presentation/Extension/Collection+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  Collection+Extension.swift
+//  SceneDepthPointCloud
+//
+//  Created by Kang Minsang on 2023/04/25.
+//  Copyright © 2023 Apple. All rights reserved.
+//
+
+import Foundation
+
+extension Collection {
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    subscript (safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/SceneDepthPointCloud/Presentation/Extension/UIView+Extension.swift
+++ b/SceneDepthPointCloud/Presentation/Extension/UIView+Extension.swift
@@ -10,12 +10,15 @@ import UIKit
 
 extension UIView {
     func fadeOut() {
-        UIView.animate(withDuration: 0.2) {
+        UIView.animate(withDuration: 0.2, animations: {
             self.alpha = 0
+        }) { _ in
+            self.isHidden = true
         }
     }
     
     func fadeIn() {
+        self.isHidden = false
         UIView.animate(withDuration: 0.3) {
             self.alpha = 1
         }
@@ -23,9 +26,11 @@ extension UIView {
     
     func disappear() {
         self.alpha = 0
+        self.isHidden = true
     }
     
     func appear() {
+        self.isHidden = false
         self.alpha = 1
     }
 }

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVC.swift
@@ -33,6 +33,8 @@ final class SelectLocationVC: UIViewController {
         layout.sectionInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         return UICollectionView(frame: .zero, collectionViewLayout: layout)
     }()
+    private var collectionViewBottom: NSLayoutConstraint!
+    private var collectionViewHeight: NSLayoutConstraint!
     /// 선택 및 데이터 업로드 버튼
     private let bottomButton = SelectLocationLargeButton()
     /// 측정위치 선택화면 관련된 로직담당 객체
@@ -95,7 +97,7 @@ extension SelectLocationVC {
         self.mapView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.mapView)
         NSLayoutConstraint.activate([
-            self.mapView.topAnchor.constraint(equalTo: self.currentLocationLabel.bottomAnchor, constant: 8),
+            self.mapView.topAnchor.constraint(equalTo: self.currentLocationLabel.bottomAnchor, constant: 16),
             self.mapView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             self.mapView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
             self.mapView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -80)
@@ -138,12 +140,17 @@ extension SelectLocationVC {
         // buildingListView
         self.buildingListView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.buildingListView)
+        
+        self.collectionViewBottom = self.buildingListView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -80)
+        
         NSLayoutConstraint.activate([
-            self.buildingListView.topAnchor.constraint(equalTo: self.currentLocationLabel.bottomAnchor, constant: 8),
+            self.buildingListView.topAnchor.constraint(equalTo: self.currentLocationLabel.bottomAnchor, constant: 16),
             self.buildingListView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             self.buildingListView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            self.buildingListView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -80)
+            self.collectionViewBottom
         ])
+        
+        self.collectionViewHeight = self.buildingListView.heightAnchor.constraint(equalToConstant: 60)
     }
     
     /// mapView 화면을 표시할 초기화 함수
@@ -241,6 +248,10 @@ extension SelectLocationVC {
                     self?.mapView.isScrollEnabled = false
                     self?.buildingListView.fadeIn()
                     self?.bottomButton.changeStatus(to: .beforeSetting)
+                case .setIndoorInfo:
+                    self?.collectionViewBottom.isActive = false
+                    self?.collectionViewHeight.isActive = true
+                    self?.mapView.isScrollEnabled = false
                 default:
                     return
                 }
@@ -265,6 +276,8 @@ extension SelectLocationVC: MKMapViewDelegate {
     /// mapView 위치 이동으로 인해 지역이 변경됨을 수신하는 함수
     func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
         // mapView 의 중심좌표로 locationData 를 업데이트 한다
+        guard self.viewModel?.mode == .selectLocation else { return }
+        
         let center = mapView.centerCoordinate
         self.viewModel?.updateLocation(to: center)
     }
@@ -278,7 +291,7 @@ extension SelectLocationVC: UICollectionViewDelegateFlowLayout {
 
 extension SelectLocationVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        print("select")
+        self.viewModel?.selectBuilding(to: indexPath.item)
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
@@ -29,6 +29,7 @@ final class SelectLocationVM {
     /// 네트워크 통신으로 인한 Error 발생값
     @Published private(set) var networkError: (title: String, text: String)?
     /// 건물리스트 api 사용시 pagenation 을 위한 현재 page 값
+    @Published private(set) var indoorFloor: Int?
     private var page: Int = 1
     /// pagenation 불가능 여부값
     private(set) var isLastPage: Bool = false
@@ -92,8 +93,10 @@ extension SelectLocationVM {
             self.fetchBuildingList()
         case .selectBuilding:
             self.mode = .setIndoorInfo
-        default:
-            return
+        case .setIndoorInfo:
+            self.mode = .done
+        case .done:
+            print("upload")
         }
     }
     
@@ -106,9 +109,13 @@ extension SelectLocationVM {
             self.buildingList = []
             self.mode = .selectLocation
         case .setIndoorInfo:
+            self.page = 1
+            self.isLastPage = false
+            self.buildingList = []
+            self.fetchBuildingList()
             self.mode = .selectBuilding
-        default:
-            return
+        case .done:
+            self.mode = .setIndoorInfo
         }
     }
     
@@ -121,6 +128,10 @@ extension SelectLocationVM {
         selected.updateUUID()
         self.changeMode()
         self.buildingList = [selected]
+    }
+    
+    func setIndoorValue(to floor: Int?) {
+        self.indoorFloor = floor
     }
 }
 

--- a/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/SelectLocationVM.swift
@@ -90,6 +90,8 @@ extension SelectLocationVM {
             self.page = 1
             self.isLastPage = false
             self.fetchBuildingList()
+        case .selectBuilding:
+            self.mode = .setIndoorInfo
         default:
             return
         }
@@ -103,9 +105,22 @@ extension SelectLocationVM {
         case .selectBuilding:
             self.buildingList = []
             self.mode = .selectLocation
+        case .setIndoorInfo:
+            self.mode = .selectBuilding
         default:
             return
         }
+    }
+    
+    func selectBuilding(to index: Int) {
+        guard var selected = self.buildingList[safe: index] else {
+            print("/// out of index: \(index)")
+            return
+        }
+        
+        selected.updateUUID()
+        self.changeMode()
+        self.buildingList = [selected]
     }
 }
 

--- a/SceneDepthPointCloud/Presentation/SelectLocation/View/IndoorSettingView.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/View/IndoorSettingView.swift
@@ -1,0 +1,98 @@
+//
+//  IndoorSettingView.swift
+//  SceneDepthPointCloud
+//
+//  Created by Kang Minsang on 2023/04/25.
+//  Copyright © 2023 Apple. All rights reserved.
+//
+
+import UIKit
+
+final class IndoorSettingView: UIView {
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: 22, weight: .semibold)
+        label.textColor = .white
+        label.textAlignment = .center
+        label.text = "실내 위치를 설정하세요"
+        return label
+    }()
+    let floorSwitch: UISegmentedControl = {
+        let selector = UISegmentedControl(items: ["지하", "지상"])
+        selector.translatesAutoresizingMaskIntoConstraints = false
+        selector.selectedSegmentTintColor = UIColor(named: "mainColor")
+        selector.backgroundColor = UIColor(named: "selectLocationBackground")
+        selector.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: .normal)
+        selector.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: .selected)
+        return selector
+    }()
+    let floorField: UITextField = {
+        let textField = UITextField()
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.backgroundColor = .clear
+        textField.font = UIFont.systemFont(ofSize: 17, weight: .medium)
+        textField.textAlignment = .center
+        textField.textColor = UIColor(named: "mainColor")
+        textField.keyboardType = .numbersAndPunctuation
+        textField.borderStyle = .roundedRect
+        textField.returnKeyType = .done
+        
+        NSLayoutConstraint.activate([
+            textField.widthAnchor.constraint(equalToConstant: 52),
+            textField.heightAnchor.constraint(equalToConstant: 30)
+        ])
+        return textField
+    }()
+    let floorLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        label.textColor = .white
+        label.textAlignment = .left
+        label.text = "층"
+        return label
+    }()
+    
+    convenience init() {
+        self.init(frame: CGRect())
+        self.configure()
+    }
+    
+    private func configure() {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.backgroundColor = .clear
+        
+        self.addSubview(self.titleLabel)
+        NSLayoutConstraint.activate([
+            self.titleLabel.topAnchor.constraint(equalTo: self.topAnchor),
+            self.titleLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+        ])
+        
+        let frameView = UIView()
+        frameView.translatesAutoresizingMaskIntoConstraints = false
+        frameView.backgroundColor = UIColor(named: "buildingCellBackgroundColor")
+        frameView.layer.cornerRadius = 8
+        frameView.layer.cornerCurve = .continuous
+        
+        self.addSubview(frameView)
+        NSLayoutConstraint.activate([
+            frameView.topAnchor.constraint(equalTo: self.titleLabel.bottomAnchor, constant: 16),
+            frameView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            frameView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
+            frameView.heightAnchor.constraint(equalToConstant: 60),
+            frameView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
+        
+        let stackView = UIStackView(arrangedSubviews: [self.floorSwitch, self.floorField, self.floorLabel])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 6
+        
+        frameView.addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.centerXAnchor.constraint(equalTo: frameView.centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: frameView.centerYAnchor)
+        ])
+    }
+}

--- a/SceneDepthPointCloud/Presentation/SelectLocation/View/SelectLocationLargeButton.swift
+++ b/SceneDepthPointCloud/Presentation/SelectLocation/View/SelectLocationLargeButton.swift
@@ -13,6 +13,7 @@ final class SelectLocationLargeButton: UIButton {
     enum Status {
         case selectable
         case beforeSetting
+        case settingChanged
         case uploadable
     }
     
@@ -44,9 +45,13 @@ final class SelectLocationLargeButton: UIButton {
             self.isUserInteractionEnabled = true
             self.backgroundColor = UIColor(named: "mainColor")
         case .beforeSetting:
-            self.setTitle("데이터 업로드", for: .normal)
+            self.setTitle("설정 완료", for: .normal)
             self.isUserInteractionEnabled = false
             self.backgroundColor = UIColor(named: "deActivateMainColor")
+        case .settingChanged:
+            self.setTitle("설정 완료", for: .normal)
+            self.isUserInteractionEnabled = true
+            self.backgroundColor = UIColor(named: "mainColor")
         case .uploadable:
             self.setTitle("데이터 업로드", for: .normal)
             self.isUserInteractionEnabled = true


### PR DESCRIPTION
## 개요
- Issue: #12
- SFR
    - [SFR-017](https://github.com/FreeDeveloper97/point-cloud-with-lidar/wiki/Requirements#sfr-017)
- URF
    - [UFR-APP-003](https://github.com/FreeDeveloper97/point-cloud-with-lidar/wiki/Requirements#ufr-app-003)
- UI
    - [UI-A-006](https://github.com/FreeDeveloper97/point-cloud-with-lidar/wiki/Interfaces#ui-a-006)

## 변경사항

### Issue Checklist
- [x] collectionView constraint 조절 구현
- [x] VM: selectBuilding() 구현
- [x] indoorSettingView 생성
- [x] configureIndoorSettingView() 구현
- [x] VM: indoorFloor 추가
- [x] VM: setIndoorValue() 구현
- [x] checkIndoorSetting() 구현
- [x] bindIndoorFloor() 구현

### CollectionView Constraint
collectionView 내에서 한가지 cell을 선택하면 선택된 cell만 표시되어야 한다.
collectionView를 그대로 사용하고, `dataSource` 값을 하나로 설정하여 표시하는 식으로 구현하였다.

collectionView의 크기조절을 위해서 `NSLayoutConstraint` 값으로 `bottomAnchor`값, `heightAnchor`값을 추가하였다.

cell 리스트를 표시하는 경우는 `bottomAnchor`값을 활성화, cell 한가지만 표시하는 경우는 `heightAnchor`값을 활성화 하는 식으로 조절하였다.

```swift
/// buildingListView의 bottomAnchor 값
private var collectionViewBottom: NSLayoutConstraint!
/// buildingListView의 heightAnchor 값
private var collectionViewHeight: NSLayoutConstraint!
```
```swift
// buildingListView
self.buildingListView.translatesAutoresizingMaskIntoConstraints = false
self.view.addSubview(self.buildingListView)

self.collectionViewBottom = self.buildingListView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -80)

NSLayoutConstraint.activate([
    self.buildingListView.topAnchor.constraint(equalTo: self.currentLocationLabel.bottomAnchor, constant: 16),
    self.buildingListView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
    self.buildingListView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
    self.collectionViewBottom
])

self.collectionViewHeight = self.buildingListView.heightAnchor.constraint(equalToConstant: 60)
```
```swift
case .selectBuilding:
    self?.backButton.isHidden = false
    self?.titleLabel.changeText(to: .selectBuilding)
    self?.mapView.disappear()
    self?.mapView.isScrollEnabled = false
    self?.buildingListView.fadeIn()
    self?.collectionViewHeight.isActive = false
    self?.collectionViewBottom.isActive = true
    self?.indoorSettingView.fadeOut()
    self?.bottomButton.changeStatus(to: .beforeSetting)
case .setIndoorInfo:
    self?.collectionViewBottom.isActive = false
    self?.collectionViewHeight.isActive = true
    self?.indoorSettingView.fadeIn()
    self?.bottomButton.changeStatus(to: .beforeSetting)
```

### Textfield: done
`IndoorSettingView`에서 textField를 통해 층수를 정수형태로 입력받는다.
입력 후 키보드를 내리는 액션이 필요한데, 이부분을 done(완료)을 누르면 제거되도록 구현하였다.

다만 textField상에 숫자형태로 입력을 제공하면서 done을 표시하기 위해서 `textField.keyboardType = .numbersAndPunctuation` 설정과 `textField.returnKeyType = .done`를 설정하였다.
```swift
let floorField: UITextField = {
    let textField = UITextField()
    textField.translatesAutoresizingMaskIntoConstraints = false
    textField.backgroundColor = .clear
    textField.font = UIFont.systemFont(ofSize: 17, weight: .medium)
    textField.textAlignment = .center
    textField.textColor = UIColor(named: "mainColor")
    textField.keyboardType = .numbersAndPunctuation
    textField.borderStyle = .roundedRect
    textField.returnKeyType = .done

    NSLayoutConstraint.activate([
        textField.widthAnchor.constraint(equalToConstant: 52),
        textField.heightAnchor.constraint(equalToConstant: 30)
    ])
    return textField
}()
```
해당 `IndoorSettingView`를 사용하는 VC에서 delegate를 설정하여 return 액션을 연결하였다.
```swift
private func configureIndoorSettingView() {
    self.indoorSettingView.floorSwitch.addTarget(self, action: #selector(checkIndoorSetting(_:)), for: .allEvents)
    self.indoorSettingView.floorField.delegate = self
    self.indoorSettingView.alpha = 0
}
```
```swift
extension SelectLocationVC: UITextFieldDelegate {
    /// keyboard의 done 액션 수신함수를 통해 키보드내림 구현한 함수
    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
        self.checkIndoorSetting()
        self.view.endEditing(true)
        return true
    }
}
```

### 스크린샷
| collectionView 조절 | keyboard done 로직 |
| -------- | -------- |
| <img src="https://i.imgur.com/huPCdBx.gif"> | <img src="https://i.imgur.com/pnl3SHN.gif"> |

### 추가 팀 논의사항
- 건물 층 개념
    - 나라별로 층의 개념들이 각기 다름을 인지
    - 단순 Int형으로 불가능할 것 같다는 것으로 인지
    - [국가별 지상 지하층 표기방식 블로그](https://m.blog.naver.com/khd9345/221600763193) 내용을 토대로 String 타입으로 고민
    - 결론: 백엔드상에서 층별 정렬을 위해서 일단 Int형으로 구현, 추후 String 타입 필요시 고민으로 결정

## 레퍼런스
- [[Swift] 안전하게 배열 접근하기](https://wody.tistory.com/29)
- [Setting up Auto Layout constraints programmatically in Swift](https://benoitpasquier.com/auto-layout-constraint-swift/)
- [UISegmentedControl - 기본 사용 방법](https://ios-development.tistory.com/962)
- [selectedSegmentIndex](https://developer.apple.com/documentation/uikit/uisegmentedcontrol/1618575-selectedsegmentindex)
- [How to change the colors of a segment in a UISegmentedControl in iOS 13?](https://stackoverflow.com/questions/56436559/how-to-change-the-colors-of-a-segment-in-a-uisegmentedcontrol-in-ios-13)