### PR TITLE
LiDAR 데이터 추가측정을 위한 초기화 기능 구현

### DIFF
--- a/SceneDepthPointCloud.xcodeproj/project.pbxproj
+++ b/SceneDepthPointCloud.xcodeproj/project.pbxproj
@@ -614,7 +614,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				INFOPLIST_FILE = SceneDepthPointCloud/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Point Cloud";
@@ -642,7 +642,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				INFOPLIST_FILE = SceneDepthPointCloud/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Point Cloud";

--- a/SceneDepthPointCloud/Data/Network/Network.swift
+++ b/SceneDepthPointCloud/Data/Network/Network.swift
@@ -53,8 +53,8 @@ struct Network {
         }
         
         // check 용 출력
-        print("statusCode: \(statusCode)")
-        print("Data: \(String(data: data, encoding: .utf8)!)")
+//        print("statusCode: \(statusCode)")
+//        print("Data: \(String(data: data, encoding: .utf8)!)")
         
         return NetworkResult(data: data, status: status)
     }

--- a/SceneDepthPointCloud/Domain/Renderer.swift
+++ b/SceneDepthPointCloud/Domain/Renderer.swift
@@ -37,7 +37,7 @@ final class Renderer {
     private let renderDestination: RenderDestinationProvider
     private let relaxedStencilState: MTLDepthStencilState
     private let depthStencilState: MTLDepthStencilState
-    private let commandQueue: MTLCommandQueue
+    private var commandQueue: MTLCommandQueue
     private lazy var unprojectPipelineState = makeUnprojectionPipelineState()!
     private lazy var rgbPipelineState = makeRGBPipelineState()!
     private lazy var particlePipelineState = makeParticlePipelineState()!
@@ -448,5 +448,24 @@ extension Renderer {
                 self.lidarRawStringData = fileToWrite
             }
         }
+    }
+}
+
+extension Renderer {
+    /// 재측정을 위한 Renderer 초기화 함수
+    /// https://github.com/ryanphilly/IOS-PointCloud 코드 참고
+    func clearParticles() {
+        self.currentPointIndex = 0
+        self.currentPointCount = 0
+        
+        self.rgbUniformsBuffers = [MetalBuffer<RGBUniforms>]()
+        self.pointCloudUniformsBuffers = [MetalBuffer<PointCloudUniforms>]()
+        
+        self.commandQueue = device.makeCommandQueue()!
+        for _ in 0 ..< maxInFlightBuffers {
+            self.rgbUniformsBuffers.append(.init(device: device, count: 1, index: 0))
+            self.pointCloudUniformsBuffers.append(.init(device: device, count: 1, index: kPointCloudUniforms.rawValue))
+        }
+        self.particlesBuffer = .init(device: device, count: maxPoints, index: kParticleUniforms.rawValue)
     }
 }

--- a/SceneDepthPointCloud/Presentation/Main/MainVM.swift
+++ b/SceneDepthPointCloud/Presentation/Main/MainVM.swift
@@ -75,7 +75,7 @@ extension MainVM {
         case.loading:
             self.mode = .uploading
         case.uploading:
-            // MARK: Renderer 초기화 필요
+            self.resetRenderer()
             self.mode = .ready
         default:
             return
@@ -117,8 +117,8 @@ extension MainVM {
     }
     
     func uploadCancel() {
-        // MARK: renderer 초기화 필요
         self.networkError = (title: "Upload Fail", text: "Can’t Upload LiDAR Data\nPlease Try again")
+        self.resetRenderer()
         self.mode = .ready
     }
     
@@ -161,8 +161,6 @@ extension MainVM {
                       let pointCount = self?.renderer.currentPointCount else { return }
                 
                 self?.lidarData = LiDARData(rawStringData: rawStringData, pointCount: pointCount)
-                
-                // MARK: Renderer 초기화 부분 필요
             }
             .store(in: &self.cancellables)
     }
@@ -182,5 +180,10 @@ extension MainVM {
     /// locationUsecase 에서 위치정보 받아와 currentLocation 값을 반영하는 함수
     private func getLocationData() {
         self.currentLocation = self.locationUsecase.getSuitableLocation(from: self.locations)
+    }
+    
+    /// Renderer 초기화 및 재측정 설정 함수
+    private func resetRenderer() {
+        
     }
 }

--- a/SceneDepthPointCloud/Presentation/Main/MainVM.swift
+++ b/SceneDepthPointCloud/Presentation/Main/MainVM.swift
@@ -117,9 +117,9 @@ extension MainVM {
     }
     
     func uploadCancel() {
-        self.networkError = (title: "Upload Fail", text: "Can’t Upload LiDAR Data\nPlease Try again")
         self.resetRenderer()
-        self.mode = .ready
+        self.mode = .uploading
+        self.networkError = (title: "Upload Fail", text: "Can’t Upload LiDAR Data\nPlease Try again")
     }
     
     func uploadMeasuredData(location: LocationData, buildingInfo: BuildingInfo, floor: Int) {
@@ -184,6 +184,6 @@ extension MainVM {
     
     /// Renderer 초기화 및 재측정 설정 함수
     private func resetRenderer() {
-        
+        self.renderer.clearParticles()
     }
 }


### PR DESCRIPTION
## 개요
- Issue: #18 

## 변경사항
### Issue Checklist
- [x] Renderer 초기화 로직 구현
- [x] 재측정 기능 구현

### Renderer.clearParticles()
[Iphone Point Cloud Generator](https://github.com/ryanphilly/IOS-PointCloud) Github Project 코드를 참고하여 기능을 구현하였다.
해당 프로젝트는 본 프로젝트와 동일하게 Apple의 [Demo Project](https://developer.apple.com/documentation/arkit/environmental_analysis/displaying_a_point_cloud_using_scene_depth) 코드기반으로 point cloud를 측정하는 프로젝트이며,
clearParticles() 함수는 새로운 point cloud를 측정하기 위하여 Renderer 클래스를 초기화하는 기능을 담당한다.

해당 프로젝트의 clearParticles() 함수를 참고하여 Renderer 클래스를 초기화하는 기능을 구현하였다.
```swift
extension Renderer {
    /// 재측정을 위한 Renderer 초기화 함수
    /// https://github.com/ryanphilly/IOS-PointCloud 코드 참고
    func clearParticles() {
        self.currentPointIndex = 0
        self.currentPointCount = 0
        
        self.rgbUniformsBuffers = [MetalBuffer<RGBUniforms>]()
        self.pointCloudUniformsBuffers = [MetalBuffer<PointCloudUniforms>]()
        
        self.commandQueue = device.makeCommandQueue()!
        for _ in 0 ..< maxInFlightBuffers {
            self.rgbUniformsBuffers.append(.init(device: device, count: 1, index: 0))
            self.pointCloudUniformsBuffers.append(.init(device: device, count: 1, index: kPointCloudUniforms.rawValue))
        }
        self.particlesBuffer = .init(device: device, count: maxPoints, index: kParticleUniforms.rawValue)
    }
}
```
## 스크린샷
| 재측정 과정 |
| :---: |
| <img src="https://user-images.githubusercontent.com/65349445/236120859-6a13db76-9140-4348-9fe6-322e3000c8d5.gif"> |

## 레퍼런스
- [Iphone Point Cloud Generator](https://github.com/ryanphilly/IOS-PointCloud)
- [Apple Demo Project](https://developer.apple.com/documentation/arkit/environmental_analysis/displaying_a_point_cloud_using_scene_depth)
